### PR TITLE
fix: Fixed ConvTranspose module identification

### DIFF
--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -11,7 +11,7 @@ from operator import mul
 
 from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.nn.modules.conv import _ConvNd, _ConvTransposeMixin  # renamed to _ConvTransposeNd in next release
+from torch.nn.modules.conv import _ConvNd, _ConvTransposeNd
 from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd, _AdaptiveAvgPoolNd
 
 
@@ -45,7 +45,7 @@ def module_flops(module, input, output):
         return flops_tanh(module, input, output)
     elif isinstance(module, nn.Sigmoid):
         return flops_sigmoid(module, input, output)
-    elif isinstance(module, _ConvTransposeMixin):
+    elif isinstance(module, _ConvTransposeNd):
         return flops_convtransposend(module, input, output)
     elif isinstance(module, _ConvNd):
         return flops_convnd(module, input, output)

--- a/torchscan/modules/macs.py
+++ b/torchscan/modules/macs.py
@@ -10,7 +10,7 @@ from functools import reduce
 from operator import mul
 
 from torch import nn
-from torch.nn.modules.conv import _ConvNd, _ConvTransposeMixin  # renamed to _ConvTransposeNd in next release
+from torch.nn.modules.conv import _ConvNd, _ConvTransposeNd
 from torch.nn.modules.batchnorm import _BatchNorm
 from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd, _AdaptiveAvgPoolNd
 
@@ -32,7 +32,7 @@ def module_macs(module, input, output):
         return macs_linear(module, input, output)
     elif isinstance(module, (nn.Identity, nn.ReLU, nn.ELU, nn.LeakyReLU, nn.ReLU6, nn.Tanh, nn.Sigmoid)):
         return 0
-    elif isinstance(module, _ConvTransposeMixin):
+    elif isinstance(module, _ConvTransposeNd):
         return macs_convtransposend(module, input, output)
     elif isinstance(module, _ConvNd):
         return macs_convnd(module, input, output)

--- a/torchscan/modules/memory.py
+++ b/torchscan/modules/memory.py
@@ -11,7 +11,7 @@ from operator import mul
 
 from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
-from torch.nn.modules.conv import _ConvNd, _ConvTransposeMixin  # renamed to _ConvTransposeNd in next release
+from torch.nn.modules.conv import _ConvNd, _ConvTransposeNd
 from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd, _AdaptiveAvgPoolNd
 
 
@@ -42,7 +42,7 @@ def module_dmas(module, input, output):
         return dmas_sigmoid(module, input, output)
     elif isinstance(module, nn.Tanh):
         return dmas_tanh(module, input, output)
-    elif isinstance(module, _ConvTransposeMixin):
+    elif isinstance(module, _ConvTransposeNd):
         return dmas_convtransposend(module, input, output)
     elif isinstance(module, _ConvNd):
         return dmas_convnd(module, input, output)


### PR DESCRIPTION
This PR fixes ConvTranspose module identification by:
- reflecting changes introduced by https://github.com/pytorch/pytorch/pull/31784 on naming of `_ConvTranposeMixin` changed to `_ConvTranposeNd`