### PR TITLE
fix: Fixed flops estimation for pooling

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -48,7 +48,15 @@ class Tester(unittest.TestCase):
         self.assertEqual(modules.module_flops(nn.AdaptiveMaxPool2d((2, 2)),
                                               torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          3 * 32)
+        # Check that single integer output size is supported
+        self.assertEqual(modules.module_flops(nn.AdaptiveMaxPool2d(2),
+                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         3 * 32)
         self.assertEqual(modules.module_flops(nn.AdaptiveAvgPool2d((2, 2)),
+                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         5 * 32)
+        # Check that single integer output size is supported
+        self.assertEqual(modules.module_flops(nn.AdaptiveAvgPool2d(2),
                                               torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
 

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -206,9 +206,10 @@ def flops_avgpool(module, input, output):
 def flops_adaptive_maxpool(module, input, output):
     """FLOPs estimation for `torch.nn.modules.pooling._AdaptiveMaxPoolNd`"""
 
+    o_sizes = module.output_size if isinstance(module.output_size, tuple) else (module.output_size,) * (input.ndim - 2)
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], module.output_size))
+                        for i_size, o_size in zip(input.shape[2:], o_sizes))
 
     # for each spatial output element, check max element in kernel scope
     return output.numel() * (reduce(mul, kernel_size) - 1)
@@ -217,9 +218,10 @@ def flops_adaptive_maxpool(module, input, output):
 def flops_adaptive_avgpool(module, input, output):
     """FLOPs estimation for `torch.nn.modules.pooling._AdaptiveAvgPoolNd`"""
 
+    o_sizes = module.output_size if isinstance(module.output_size, tuple) else (module.output_size,) * (input.ndim - 2)
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], module.output_size))
+                        for i_size, o_size in zip(input.shape[2:], o_sizes))
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
     return output.numel() * (reduce(mul, kernel_size) - 1 + len(kernel_size))


### PR DESCRIPTION
Previously, integer output size for adaptive pooling was not supported:
```
from torchscan import summary
import torch.nn as nn
summary(nn.Sequential(nn.Conv2d(3, 32, 3), nn.AdaptiveAvgPool2d(1)).cuda(), (3, 256, 256))
```
would produce
```
~/Documents/torch-scan/torchscan/modules/flops.py in flops_adaptive_avgpool(module, input, output)
    220     # Approximate kernel_size using ratio of spatial shapes between input and output
    221     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
--> 222                         for i_size, o_size in zip(input.shape[2:], module.output_size))
    223 
    224     # for each spatial output element, sum elements in kernel scope and div by kernel size

TypeError: zip argument #2 must support iteration
```

This PR fixes the issue by casting the output size to a tuple of integer of the correct size.