### PR TITLE
fix: Fixed the support of single integer output size for adaptive pooling

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -115,7 +115,6 @@ class Tester(unittest.TestCase):
                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
 
-
         # Dropout
         self.assertEqual(modules.module_macs(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
 

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -107,6 +107,14 @@ class Tester(unittest.TestCase):
         self.assertEqual(modules.module_macs(nn.AdaptiveAvgPool2d((2, 2)),
                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
+        # Test support integer output-size support
+        self.assertEqual(modules.module_macs(nn.AdaptiveMaxPool2d(2),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         3 * 32)
+        self.assertEqual(modules.module_macs(nn.AdaptiveAvgPool2d(2),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         5 * 32)
+
 
         # Dropout
         self.assertEqual(modules.module_macs(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
@@ -144,6 +152,13 @@ class Tester(unittest.TestCase):
                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          4 * 32 + 32)
         self.assertEqual(modules.module_dmas(nn.AdaptiveMaxPool2d((2, 2)),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         4 * 32 + 32)
+        # Integer output size support
+        self.assertEqual(modules.module_dmas(nn.MaxPool2d(2),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         4 * 32 + 32)
+        self.assertEqual(modules.module_dmas(nn.AdaptiveMaxPool2d(2),
                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          4 * 32 + 32)
 

--- a/torchscan/modules/macs.py
+++ b/torchscan/modules/macs.py
@@ -136,9 +136,10 @@ def macs_avgpool(module, input, output):
 def macs_adaptive_maxpool(module, input, output):
     """MACs estimation for `torch.nn.modules.pooling._AdaptiveMaxPoolNd`"""
 
+    o_sizes = module.output_size if isinstance(module.output_size, tuple) else (module.output_size,) * (input.ndim - 2)
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], module.output_size))
+                        for i_size, o_size in zip(input.shape[2:], o_sizes))
 
     # for each spatial output element, check max element in kernel scope
     return output.numel() * (reduce(mul, kernel_size) - 1)
@@ -147,9 +148,10 @@ def macs_adaptive_maxpool(module, input, output):
 def macs_adaptive_avgpool(module, input, output):
     """MACs estimation for `torch.nn.modules.pooling._AdaptiveAvgPoolNd`"""
 
+    o_sizes = module.output_size if isinstance(module.output_size, tuple) else (module.output_size,) * (input.ndim - 2)
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], module.output_size))
+                        for i_size, o_size in zip(input.shape[2:], o_sizes))
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
     return output.numel() * (reduce(mul, kernel_size) - 1 + len(kernel_size))

--- a/torchscan/modules/memory.py
+++ b/torchscan/modules/memory.py
@@ -212,9 +212,10 @@ def dmas_pool(module, input, output):
 def dmas_adaptive_pool(module, input, output):
     """DMAs estimation for adaptive spatial pooling modules"""
 
+    o_sizes = module.output_size if isinstance(module.output_size, tuple) else (module.output_size,) * (input.ndim - 2)
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], module.output_size))
+                        for i_size, o_size in zip(input.shape[2:], o_sizes))
     # Each output element required K ** 2 memory accesses
     input_dma = reduce(mul, kernel_size) * output.numel()
 


### PR DESCRIPTION
This PR follows up on #19 to address the same issues for MACs and DMAs