### PR TITLE
feat: Added experimental support of receptive field estimation

### DIFF
--- a/test/test_crawler.py
+++ b/test/test_crawler.py
@@ -45,6 +45,14 @@ class UtilsTester(unittest.TestCase):
         sys.stdout = sys.__stdout__
         self.assertEqual(captured_output.getvalue().split('\n')[7], 'Total params: 224')
 
+        # Check receptive field
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        crawler.summary(mod, (3, 32, 32), receptive_field=True)
+        # Reset redirect.
+        sys.stdout = sys.__stdout__
+        self.assertEqual(captured_output.getvalue().split('\n')[1].rpartition('  ')[-1], 'Receptive field')
+        self.assertEqual(captured_output.getvalue().split('\n')[3].split()[-1], '3')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_crawler.py
+++ b/test/test_crawler.py
@@ -54,5 +54,6 @@ class UtilsTester(unittest.TestCase):
         self.assertEqual(captured_output.getvalue().split('\n')[1].rpartition('  ')[-1], 'Receptive field')
         self.assertEqual(captured_output.getvalue().split('\n')[3].split()[-1], '3')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -143,5 +143,44 @@ class Tester(unittest.TestCase):
         self.assertEqual(modules.module_dmas(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 17)
 
 
+    def test_module_rf(self):
+
+        # Check for unknown module that it returns 0 and throws a warning
+        self.assertEqual(modules.module_rf(MyModule(), None, None), (1, 1, 0))
+        self.assertWarns(UserWarning, modules.module_rf, MyModule(), None, None)
+
+        # Common unit tests
+        # Linear
+        self.assertEqual(modules.module_rf(nn.Linear(8, 4), torch.zeros((1, 8)), torch.zeros((1, 4))),
+                         (1, 1, 0))
+        # Activation
+        self.assertEqual(modules.module_rf(nn.Identity(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+        self.assertEqual(modules.module_rf(nn.ReLU(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+        self.assertEqual(modules.module_rf(nn.ELU(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+        self.assertEqual(modules.module_rf(nn.Sigmoid(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+        self.assertEqual(modules.module_rf(nn.Tanh(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+        # Conv
+        input_t = torch.rand((1, 3, 32, 32))
+        mod = nn.Conv2d(3, 8, 3)
+        self.assertEqual(modules.module_rf(mod, input_t, mod(input_t)), (3, 1, 0))
+        # ConvTranspose
+        mod = nn.ConvTranspose2d(3, 8, 3)
+        self.assertEqual(modules.module_rf(mod, input_t, mod(input_t)), (-3, 1, 0))
+        # BN
+        self.assertEqual(modules.module_rf(nn.BatchNorm1d(8), torch.zeros((1, 8, 4)), torch.zeros((1, 8, 4))),
+                         (1, 1, 0))
+
+        # Pooling
+        self.assertEqual(modules.module_rf(nn.MaxPool2d((2, 2)),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         (2, 2, 0))
+        self.assertEqual(modules.module_rf(nn.AdaptiveMaxPool2d((2, 2)),
+                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                         (2, 2, 0))
+
+        # Dropout
+        self.assertEqual(modules.module_rf(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), (1, 1, 0))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -142,7 +142,6 @@ class Tester(unittest.TestCase):
         # Dropout
         self.assertEqual(modules.module_dmas(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 17)
 
-
     def test_module_rf(self):
 
         # Check for unknown module that it returns 0 and throws a warning
@@ -172,10 +171,10 @@ class Tester(unittest.TestCase):
 
         # Pooling
         self.assertEqual(modules.module_rf(nn.MaxPool2d((2, 2)),
-                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                           torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          (2, 2, 0))
         self.assertEqual(modules.module_rf(nn.AdaptiveMaxPool2d((2, 2)),
-                                             torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                           torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
                          (2, 2, 0))
 
         # Dropout

--- a/torchscan/modules/__init__.py
+++ b/torchscan/modules/__init__.py
@@ -1,7 +1,9 @@
 from .flops import *
 from .macs import *
 from .memory import *
+from .receptive import *
 
 del flops
 del macs
 del memory
+del receptive

--- a/torchscan/modules/receptive.py
+++ b/torchscan/modules/receptive.py
@@ -4,6 +4,7 @@
 Module receptive field
 """
 
+import math
 import warnings
 from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
@@ -48,8 +49,8 @@ def module_rf(module, input, output):
 
 def rf_adaptive_poolnd(module, input, output):
 
-    stride = input.shape[-1] // output.shape[-1]
-    kernel_size = 2 * (input.shape[-1] % output.shape[-1]) + 1
-    padding = (stride * (output.shape[-1] - 1) - input.shape[-1] - kernel_size) / 2
+    stride = math.ceil(input.shape[-1] / output.shape[-1])
+    kernel_size = stride
+    padding = (input.shape[-1] - kernel_size * stride) / 2
 
     return kernel_size, stride, padding

--- a/torchscan/modules/receptive.py
+++ b/torchscan/modules/receptive.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+"""
+Module receptive field
+"""
+
+import warnings
+from torch import nn
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.conv import _ConvNd, _ConvTransposeNd
+from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd, _AdaptiveAvgPoolNd
+
+
+__all__ = ['module_rf']
+
+
+def module_rf(module, input, output):
+    """Estimate the spatial receptive field of the module
+
+    Args:
+        module (torch.nn.Module): PyTorch module
+        input (torch.Tensor): input to the module
+        output (torch.Tensor): output of the module
+    Returns:
+        int: receptive field
+        int: effective stride
+        int: effective padding
+    """
+    if isinstance(module, (nn.Identity, nn.ReLU, nn.ELU, nn.LeakyReLU, nn.ReLU6, nn.Tanh, nn.Sigmoid, _BatchNorm)):
+        return 1, 1, 0
+    elif isinstance(module, _ConvTransposeNd):
+        k = module.kernel_size[0] if isinstance(module.kernel_size, tuple) else module.kernel_size
+        s = module.stride[0] if isinstance(module.stride, tuple) else module.stride
+        return -k, 1 / s, 0
+    elif isinstance(module, (_ConvNd, _MaxPoolNd, _AvgPoolNd)):
+        k = module.kernel_size[0] if isinstance(module.kernel_size, tuple) else module.kernel_size
+        s = module.stride[0] if isinstance(module.stride, tuple) else module.stride
+        p = module.padding[0] if isinstance(module.padding, tuple) else module.padding
+        return k, s, p
+    elif isinstance(module, (_AdaptiveMaxPoolNd, _AdaptiveAvgPoolNd)):
+        return rf_adaptive_poolnd(module, input, output)
+    elif isinstance(module, (nn.Dropout, nn.Linear)):
+        return 1, 1, 0
+    else:
+        warnings.warn(f'Module type not supported: {module.__class__.__name__}')
+        return 1, 1, 0
+
+
+def rf_adaptive_poolnd(module, input, output):
+
+    stride = input.shape[-1] // output.shape[-1]
+    kernel_size = 2 * (input.shape[-1] % output.shape[-1]) + 1
+    padding = (stride * (output.shape[-1] - 1) - input.shape[-1] - kernel_size) / 2
+
+    return kernel_size, stride, padding


### PR DESCRIPTION
As suggested in #12, this PR adds support for receptive field estimation by:
- computing layer-specific effective receptive field, stride and padding
- aggregating them for compatibility with the `max_depth` attribute
- adding corresponding unittests on receptive field estimation
- adding a boolean argument to the `summary` function, which adds the receptive field information to the console summary (default: `False`)

Here are a few samples:
```
from torchvision.models import vgg16
from torchscan import summary
summary(vgg16().eval().cuda(), (3, 224, 224), receptive_field=True)
```
yields
```
__________________________________________________________________________________________________________
Layer                        Type                  Output Shape              Param #         Receptive field
==========================================================================================================
vgg                          VGG                   (-1, 1000)                0               212            
├─features                   Sequential            (-1, 512, 7, 7)           0               212            
|    └─0                     Conv2d                (-1, 64, 224, 224)        1,792           212            
|    └─1                     ReLU                  (-1, 64, 224, 224)        0               210            
|    └─2                     Conv2d                (-1, 64, 224, 224)        36,928          210            
|    └─3                     ReLU                  (-1, 64, 224, 224)        0               208            
|    └─4                     MaxPool2d             (-1, 64, 112, 112)        0               208            
|    └─5                     Conv2d                (-1, 128, 112, 112)       73,856          104            
|    └─6                     ReLU                  (-1, 128, 112, 112)       0               102            
|    └─7                     Conv2d                (-1, 128, 112, 112)       147,584         102            
|    └─8                     ReLU                  (-1, 128, 112, 112)       0               100            
|    └─9                     MaxPool2d             (-1, 128, 56, 56)         0               100            
|    └─10                    Conv2d                (-1, 256, 56, 56)         295,168         50             
|    └─11                    ReLU                  (-1, 256, 56, 56)         0               48             
|    └─12                    Conv2d                (-1, 256, 56, 56)         590,080         48             
|    └─13                    ReLU                  (-1, 256, 56, 56)         0               46             
|    └─14                    Conv2d                (-1, 256, 56, 56)         590,080         46             
|    └─15                    ReLU                  (-1, 256, 56, 56)         0               44             
|    └─16                    MaxPool2d             (-1, 256, 28, 28)         0               44             
|    └─17                    Conv2d                (-1, 512, 28, 28)         1,180,160       22             
|    └─18                    ReLU                  (-1, 512, 28, 28)         0               20             
|    └─19                    Conv2d                (-1, 512, 28, 28)         2,359,808       20             
|    └─20                    ReLU                  (-1, 512, 28, 28)         0               18             
|    └─21                    Conv2d                (-1, 512, 28, 28)         2,359,808       18             
|    └─22                    ReLU                  (-1, 512, 28, 28)         0               16             
|    └─23                    MaxPool2d             (-1, 512, 14, 14)         0               16             
|    └─24                    Conv2d                (-1, 512, 14, 14)         2,359,808       8              
|    └─25                    ReLU                  (-1, 512, 14, 14)         0               6              
|    └─26                    Conv2d                (-1, 512, 14, 14)         2,359,808       6              
|    └─27                    ReLU                  (-1, 512, 14, 14)         0               4              
|    └─28                    Conv2d                (-1, 512, 14, 14)         2,359,808       4              
|    └─29                    ReLU                  (-1, 512, 14, 14)         0               2              
|    └─30                    MaxPool2d             (-1, 512, 7, 7)           0               2              
├─avgpool                    AdaptiveAvgPool2d     (-1, 512, 7, 7)           0               1              
├─classifier                 Sequential            (-1, 1000)                0               1              
|    └─0                     Linear                (-1, 4096)                102,764,544     1              
|    └─1                     ReLU                  (-1, 4096)                0               1              
|    └─2                     Dropout               (-1, 4096)                0               1              
|    └─3                     Linear                (-1, 4096)                16,781,312      1              
|    └─4                     ReLU                  (-1, 4096)                0               1              
|    └─5                     Dropout               (-1, 4096)                0               1              
|    └─6                     Linear                (-1, 1000)                4,097,000       1              
==========================================================================================================
Trainable params: 138,357,544
Non-trainable params: 0
Total params: 138,357,544
----------------------------------------------------------------------------------------------------------
Model size (params + buffers): 527.79 Mb
Framework & CUDA overhead: 504.26 Mb
Total RAM usage: 1032.05 Mb
----------------------------------------------------------------------------------------------------------
Floating Point Operations on forward: 30.96 GFLOPs
Multiply-Accumulations on forward: 15.47 GMACs
Direct memory accesses on forward: 15.52 GDMAs
__________________________________________________________________________________________________________

```

and using max_depth option:

```
____________________________________________________________________________________________________________
Layer                        Type                  Output Shape              Param #         Receptive field
============================================================================================================
vgg                          VGG                   (-1, 1000)                0               212            
├─features                   Sequential            (-1, 512, 7, 7)           14,714,688      212            
├─avgpool                    AdaptiveAvgPool2d     (-1, 512, 7, 7)           0               1              
├─classifier                 Sequential            (-1, 1000)                123,642,856     1              
============================================================================================================
Trainable params: 138,357,544
Non-trainable params: 0
Total params: 138,357,544
------------------------------------------------------------------------------------------------------------
Model size (params + buffers): 527.79 Mb
Framework & CUDA overhead: 487.38 Mb
Total RAM usage: 1015.17 Mb
------------------------------------------------------------------------------------------------------------
Floating Point Operations on forward: 30.96 GFLOPs
Multiply-Accumulations on forward: 15.47 GMACs
Direct memory accesses on forward: 15.52 GDMAs
____________________________________________________________________________________________________________

```

_Note: this feature is experimental and only supports highway nets for now (i.e. models with multiple branches or residual connections are not correctly supported in this PR)_