### PR TITLE
feat: Switched RF computation basis to input

### DIFF
--- a/test/test_crawler.py
+++ b/test/test_crawler.py
@@ -32,6 +32,13 @@ class UtilsTester(unittest.TestCase):
         self.assertIsInstance(res, dict)
         self.assertEqual(res['overall']['grad_params'], 224)
         self.assertEqual(res['layers'][0]['output_shape'], (-1, 8, 30, 30))
+        # Check receptive field order
+        mod = nn.Sequential(nn.Conv2d(3, 8, 5), nn.ReLU(), nn.Conv2d(8, 16, 3))
+        inv_res = crawler.crawl_module(mod, (3, 32, 32), relative_to_input=False)
+        inv_order = [(_layer['rf'], _layer['s'], _layer['p']) for _layer in res['layers']]
+        res = crawler.crawl_module(mod, (3, 32, 32), relative_to_input=True)
+        order = [(_layer['rf'], _layer['s'], _layer['p']) for _layer in inv_res['layers']]
+        self.assertTrue(all(x == y for x, y in zip(order[-1], inv_order[0])))
 
     def test_summary(self):
 

--- a/test/test_crawler.py
+++ b/test/test_crawler.py
@@ -32,13 +32,6 @@ class UtilsTester(unittest.TestCase):
         self.assertIsInstance(res, dict)
         self.assertEqual(res['overall']['grad_params'], 224)
         self.assertEqual(res['layers'][0]['output_shape'], (-1, 8, 30, 30))
-        # Check receptive field order
-        mod = nn.Sequential(nn.Conv2d(3, 8, 5), nn.ReLU(), nn.Conv2d(8, 16, 3))
-        inv_res = crawler.crawl_module(mod, (3, 32, 32), relative_to_input=False)
-        inv_order = [(_layer['rf'], _layer['s'], _layer['p']) for _layer in res['layers']]
-        res = crawler.crawl_module(mod, (3, 32, 32), relative_to_input=True)
-        order = [(_layer['rf'], _layer['s'], _layer['p']) for _layer in inv_res['layers']]
-        self.assertTrue(all(x == y for x, y in zip(order[-1], inv_order[0])))
 
     def test_summary(self):
 

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -236,14 +236,14 @@ def crawl_module(
     _rf, _s, _p = 1, 1, 0
     if not relative_to_input:
         info = info[::-1]
+
     for fw_idx, _layer in enumerate(info):
         _rf = _layer['s'] * (_rf - 1) + _layer['rf']
         _s *= _layer['s']
         _p = _layer['s'] * _p + _layer['p']
-
-        info[fw_idx]['rf'] = _rf
-        info[fw_idx]['s'] = _s
-        info[fw_idx]['p'] = _p
+        info[fw_idx if relative_to_input else -fw_idx]['rf'] = _rf
+        info[fw_idx if relative_to_input else -fw_idx]['s'] = _s
+        info[fw_idx if relative_to_input else -fw_idx]['p'] = _p
 
     return dict(overheads=dict(cuda=dict(pre=cuda_overhead, fwd=get_process_gpu_ram(os.getpid()) - reserved_ram),
                                framework=dict(pre=framework_overhead, fwd=diff_ram)),

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -30,8 +30,8 @@ def apply(module: Module, fn: Callable[[Module, str], None], name: Optional[str]
 def crawl_module(
     module: Module,
     input_shape: Union[List[Tuple[int, ...]], Tuple[int, ...]],
-    dtype: Optional[Union[torch.dtype, Iterable[torch.dtype]]] = None,
-    max_depth: Optional[int] = None
+    relative_to_input: bool = False,
+    dtype: Optional[Union[torch.dtype, Iterable[torch.dtype]]] = None
 ) -> Dict[str, Any]:
     """Retrieves module information for an expected input tensor shape
 
@@ -44,8 +44,8 @@ def crawl_module(
     Args:
         module: module to inspect
         input_shape: expected input shapes
+        relative_to_input: whether the receptive_field should be computed relatively to input or outputs
         dtype: data type of each input argument to the module
-        max_depth: maximum depth of layer information
     Returns:
         layer and overhead information
     """
@@ -234,14 +234,16 @@ def crawl_module(
 
     # Update cumulative receptive field
     _rf, _s, _p = 1, 1, 0
-    for fw_idx, _layer in enumerate(info[::-1]):
+    if not relative_to_input:
+        info = info[::-1]
+    for fw_idx, _layer in enumerate(info):
         _rf = _layer['s'] * (_rf - 1) + _layer['rf']
         _s *= _layer['s']
         _p = _layer['s'] * _p + _layer['p']
 
-        info[len(info) - 1 - fw_idx]['rf'] = _rf
-        info[len(info) - 1 - fw_idx]['s'] = _s
-        info[len(info) - 1 - fw_idx]['p'] = _p
+        info[fw_idx]['rf'] = _rf
+        info[fw_idx]['s'] = _s
+        info[fw_idx]['p'] = _p
 
     return dict(overheads=dict(cuda=dict(pre=cuda_overhead, fwd=get_process_gpu_ram(os.getpid()) - reserved_ram),
                                framework=dict(pre=framework_overhead, fwd=diff_ram)),
@@ -255,7 +257,8 @@ def summary(
     input_shape: Tuple[int, ...],
     wrap_mode: str = 'mid',
     max_depth: Optional[int] = None,
-    receptive_field: bool = False
+    receptive_field: bool = False,
+    relative_to_input: bool = False,
 ) -> None:
     """Print module summary for an expected input tensor shape
 
@@ -271,10 +274,11 @@ def summary(
         wrap_mode: if a value is too long, where the wrapping should be performed
         max_depth: maximum depth of layer information
         receptive_field: whether receptive field estimation should be performed
+        relative_to_input: if `receptive_field` is True, computes the receptive field relative to inputs
     """
 
     # Get the summary dict
-    module_info = crawl_module(module, input_shape)
+    module_info = crawl_module(module, input_shape, relative_to_input)
     # Aggregate until max_depth
     if isinstance(max_depth, int):
         module_info = aggregate_info(module_info, max_depth)

--- a/torchscan/utils.py
+++ b/torchscan/utils.py
@@ -164,14 +164,16 @@ def aggregate_info(info: Dict[str, Any], max_depth: int) -> Dict[str, Any]:
                 p_size += _layer['param_size']
                 num_buffers += _layer['num_buffers']
                 b_size += _layer['buffer_size']
+                # Take the last receptive field values
+                rf, s, p = _layer['rf'], _layer['s'], _layer['p']
 
             # Update info
             info['layers'][fw_idx]['flops'] = flops
             info['layers'][fw_idx]['macs'] = macs
             info['layers'][fw_idx]['dmas'] = dmas
-            info['layers'][fw_idx]['rf'] = info['layers'][fw_idx + 1]['rf']
-            info['layers'][fw_idx]['s'] = info['layers'][fw_idx + 1]['s']
-            info['layers'][fw_idx]['p'] = info['layers'][fw_idx + 1]['p']
+            info['layers'][fw_idx]['rf'] = rf
+            info['layers'][fw_idx]['s'] = s
+            info['layers'][fw_idx]['p'] = p
             info['layers'][fw_idx]['grad_params'] = grad_p
             info['layers'][fw_idx]['nograd_params'] = nograd_p
             info['layers'][fw_idx]['param_size'] = p_size


### PR DESCRIPTION
This PR switches the relative layer of receptive field computation to input rather than output to close #27 

Running the following snippet:

```
from torch import nn
from torchscan import summary

mod = nn.Sequential(nn.Conv2d(3, 8, 5), nn.ReLU(), nn.Conv2d(8, 16, 3))
summary(mod.eval(), (3, 32, 32), receptive_field=True)
```

yields:
```
__________________________________________________________________________
Layer         Type          Output Shape        Param #    Receptive field
==========================================================================

sequential    Sequential    (-1, 16, 26, 26)    0          1              
├─0           Conv2d        (-1, 8, 28, 28)     608        5              
├─1           ReLU          (-1, 8, 28, 28)     0          5              
├─2           Conv2d        (-1, 16, 26, 26)    1,168      7              
==========================================================================

Trainable params: 1,776
Non-trainable params: 0
Total params: 1,776
--------------------------------------------------------------------------

Model size (params + buffers): 0.01 Mb
Framework & CUDA overhead: 427.00 Mb
Total RAM usage: 427.01 Mb
--------------------------------------------------------------------------

Floating Point Operations on forward: 2.50 MFLOPs
Multiply-Accumulations on forward: 1.25 MMACs
Direct memory accesses on forward: 1.28 MDMAs
__________________________________________________________________________

```
