### PR TITLE
fix: Fixed RF computation and added effective stride and padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ from torchvision.models import vgg16
 from torchscan import summary
 
 model = vgg16().eval().cuda()
-summary(model, (3, 224, 224), receptive_field=True, max_depth=1)
+summary(model, (3, 224, 224), receptive_field=True, max_depth=0)
 ```
 
 which will add the layer's receptive field (relatively to the last convolutional layer) to the summary.
@@ -121,45 +121,47 @@ which will add the layer's receptive field (relatively to the last convolutional
 
 Below are the results for classification models supported by `torchvision` for a single image with 3 color channels of size `224x224` (apart from  `inception_v3`   which uses `299x299`).
 
-| Model              | Params (M) | FLOPs (G) | MACs (G) | DMAs (G) |
-| ------------------ | ---------- | --------- | -------- | -------- |
-| alexnet            | 61.1       | 1.43      | 0.71     | 0.72     |
-| googlenet          | 6.62       | 3.01      | 1.51     | 1.53     |
-| vgg11              | 132.86     | 15.23     | 7.61     | 7.64     |
-| vgg11_bn           | 132.87     | 15.26     | 7.63     | 7.66     |
-| vgg13              | 133.05     | 22.63     | 11.31    | 11.35    |
-| vgg13_bn           | 133.05     | 22.68     | 11.33    | 11.37    |
-| vgg16              | 138.36     | 30.96     | 15.47    | 15.52    |
-| vgg16_bn           | 138.37     | 31.01     | 15.5     | 15.55    |
-| vgg19              | 143.67     | 39.28     | 19.63    | 19.69    |
-| vgg19_bn           | 143.68     | 39.34     | 19.66    | 19.72    |
-| resnet18           | 11.69      | 3.64      | 1.82     | 1.84     |
-| resnet34           | 21.8       | 7.34      | 3.67     | 3.7      |
-| resnet50           | 25.56      | 8.21      | 4.11     | 4.15     |
-| resnet101          | 44.55      | 15.66     | 7.83     | 7.9      |
-| resnet152          | 60.19      | 23.1      | 11.56    | 11.65    |
-| inception_v3       | 27.16      | 11.45     | 5.73     | 5.76     |
-| squeezenet1_0      | 1.25       | 1.64      | 0.82     | 0.83     |
-| squeezenet1_1      | 1.24       | 0.7       | 0.35     | 0.36     |
-| wide_resnet50_2    | 68.88      | 22.84     | 11.43    | 11.51    |
-| wide_resnet101_2   | 126.89     | 45.58     | 22.8     | 22.95    |
-| densenet121        | 7.98       | 5.74      | 2.87     | 2.9      |
-| densenet161        | 28.68      | 15.59     | 7.79     | 7.86     |
-| densenet169        | 14.15      | 6.81      | 3.4      | 3.44     |
-| densenet201        | 20.01      | 8.7       | 4.34     | 4.39     |
-| resnext50_32x4d    | 25.03      | 8.51      | 4.26     | 4.3      |
-| resnext101_32x8d   | 88.79      | 32.93     | 16.48    | 16.61    |
-| mobilenet_v2       | 3.5        | 0.63      | 0.31     | 0.32     |
-| shufflenet_v2_x0_5 | 1.37       | 0.09      | 0.04     | 0.05     |
-| shufflenet_v2_x1_0 | 2.28       | 0.3       | 0.15     | 0.15     |
-| shufflenet_v2_x1_5 | 3.5        | 0.6       | 0.3      | 0.31     |
-| shufflenet_v2_x2_0 | 7.39       | 1.18      | 0.59     | 0.6      |
-| mnasnet0_5         | 2.22       | 0.22      | 0.11     | 0.12     |
-| mnasnet0_75        | 3.17       | 0.45      | 0.23     | 0.24     |
-| mnasnet1_0         | 4.38       | 0.65      | 0.33     | 0.34     |
-| mnasnet1_3         | 6.28       | 1.08      | 0.54     | 0.56     |
+| Model              | Params (M) | FLOPs (G) | MACs (G) | DMAs (G) | RF   |
+| ------------------ | ---------- | --------- | -------- | -------- | ---- |
+| alexnet            | 61.1       | 1.43      | 0.71     | 0.72     | 195  |
+| googlenet          | 6.62       | 3.01      | 1.51     | 1.53     | --   |
+| vgg11              | 132.86     | 15.23     | 7.61     | 7.64     | 150  |
+| vgg11_bn           | 132.87     | 15.26     | 7.63     | 7.66     | 150  |
+| vgg13              | 133.05     | 22.63     | 11.31    | 11.35    | 156  |
+| vgg13_bn           | 133.05     | 22.68     | 11.33    | 11.37    | 156  |
+| vgg16              | 138.36     | 30.96     | 15.47    | 15.52    | 212  |
+| vgg16_bn           | 138.37     | 31.01     | 15.5     | 15.55    | 212  |
+| vgg19              | 143.67     | 39.28     | 19.63    | 19.69    | 268  |
+| vgg19_bn           | 143.68     | 39.34     | 19.66    | 19.72    | 268  |
+| resnet18           | 11.69      | 3.64      | 1.82     | 1.84     | --   |
+| resnet34           | 21.8       | 7.34      | 3.67     | 3.7      | --   |
+| resnet50           | 25.56      | 8.21      | 4.11     | 4.15     | --   |
+| resnet101          | 44.55      | 15.66     | 7.83     | 7.9      | --   |
+| resnet152          | 60.19      | 23.1      | 11.56    | 11.65    | --   |
+| inception_v3       | 27.16      | 11.45     | 5.73     | 5.76     | --   |
+| squeezenet1_0      | 1.25       | 1.64      | 0.82     | 0.83     | --   |
+| squeezenet1_1      | 1.24       | 0.7       | 0.35     | 0.36     | --   |
+| wide_resnet50_2    | 68.88      | 22.84     | 11.43    | 11.51    | --   |
+| wide_resnet101_2   | 126.89     | 45.58     | 22.8     | 22.95    | --   |
+| densenet121        | 7.98       | 5.74      | 2.87     | 2.9      | --   |
+| densenet161        | 28.68      | 15.59     | 7.79     | 7.86     | --   |
+| densenet169        | 14.15      | 6.81      | 3.4      | 3.44     | --   |
+| densenet201        | 20.01      | 8.7       | 4.34     | 4.39     | --   |
+| resnext50_32x4d    | 25.03      | 8.51      | 4.26     | 4.3      | --   |
+| resnext101_32x8d   | 88.79      | 32.93     | 16.48    | 16.61    | --   |
+| mobilenet_v2       | 3.5        | 0.63      | 0.31     | 0.32     | --   |
+| shufflenet_v2_x0_5 | 1.37       | 0.09      | 0.04     | 0.05     | --   |
+| shufflenet_v2_x1_0 | 2.28       | 0.3       | 0.15     | 0.15     | --   |
+| shufflenet_v2_x1_5 | 3.5        | 0.6       | 0.3      | 0.31     | --   |
+| shufflenet_v2_x2_0 | 7.39       | 1.18      | 0.59     | 0.6      | --   |
+| mnasnet0_5         | 2.22       | 0.22      | 0.11     | 0.12     | --   |
+| mnasnet0_75        | 3.17       | 0.45      | 0.23     | 0.24     | --   |
+| mnasnet1_0         | 4.38       | 0.65      | 0.33     | 0.34     | --   |
+| mnasnet1_3         | 6.28       | 1.08      | 0.54     | 0.56     | --   |
 
 The above results were produced using the `scripts/benchmark.py` script.
+
+*Note: receptive field computation is currently only valid for highway nets.*
 
 
 
@@ -171,7 +173,7 @@ The project is currently under development, here are the objectives for the next
 
 - [x] Package distribution: add a conda package.
 
-- [ ] Shared parameter support (cf. [discussion](https://discuss.pytorch.org/t/repeated-model-layers-real-or-torchsummary-bug/26489))
+- [x] Shared parameter support (cf. [discussion](https://discuss.pytorch.org/t/repeated-model-layers-real-or-torchsummary-bug/26489))
 
 - [ ] Result exporting: add a csv export option.
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,5 +1,4 @@
 #!usr/bin/python
-# -*- coding: utf-8 -*-
 
 """
 Torchvision benchmark
@@ -30,8 +29,13 @@ def main():
 
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
-    print(f"{'Model':<20} | {'Params (M)':<10} | {'FLOPs (G)':<10} | {'MACs (G)':<10} | {'DMAs (G)':<10}")
-    print('-' * 71)
+    margin = 4
+    headers = ['Model', 'Params (M)', 'FLOPs (G)', 'MACs (G)', 'DMAs (G)', 'RF']
+    max_w = [20, 10, 10, 10, 10, 10]
+
+    info_str = [(' ' * margin).join([f"{col_name:<{col_w}}" for col_name, col_w in zip(headers, max_w)])]
+    info_str.append('-' * len(info_str[0]))
+    print('\n'.join(info_str))
     for name in TORCHVISION_MODELS:
         model = models.__dict__[name]().eval().to(device)
         dsize = (3, 224, 224)
@@ -43,10 +47,10 @@ def main():
         tot_flops = sum(layer['flops'] for layer in model_info['layers'])
         tot_macs = sum(layer['macs'] for layer in model_info['layers'])
         tot_dmas = sum(layer['dmas'] for layer in model_info['layers'])
-        print(f"{name:<20} | {tot_params / 1e6:<10.2f} | {tot_flops / 1e9:<10.2f} | {tot_macs / 1e9:<10.2f} | "
-              f"{tot_dmas / 1e9:<10.2f}")
+        rf = model_info['layers'][0]['rf']
+        print(f"{name:<{max_w[0]}} | {tot_params / 1e6:<{max_w[1]}.2f} | {tot_flops / 1e9:<{max_w[2]}.2f} | "
+              f"{tot_macs / 1e9:<{max_w[3]}.2f} | {tot_dmas / 1e9:<{max_w[4]}.2f} | {rf:<{max_w[5]}.0f}")
 
 
 if __name__ == "__main__":
-
     main()

--- a/test/test_crawler.py
+++ b/test/test_crawler.py
@@ -53,6 +53,14 @@ class UtilsTester(unittest.TestCase):
         sys.stdout = sys.__stdout__
         self.assertEqual(captured_output.getvalue().split('\n')[1].rpartition('  ')[-1], 'Receptive field')
         self.assertEqual(captured_output.getvalue().split('\n')[3].split()[-1], '3')
+        # Check effective stats
+        captured_output = io.StringIO()
+        sys.stdout = captured_output
+        crawler.summary(mod, (3, 32, 32), receptive_field=True, effective_rf_stats=True)
+        # Reset redirect.
+        sys.stdout = sys.__stdout__
+        self.assertEqual(captured_output.getvalue().split('\n')[1].rpartition('  ')[-1], 'Effective padding')
+        self.assertEqual(captured_output.getvalue().split('\n')[3].split()[-1], '0')
 
 
 if __name__ == '__main__':

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -252,7 +252,8 @@ def summary(
     input_shape: Tuple[int, ...],
     wrap_mode: str = 'mid',
     max_depth: Optional[int] = None,
-    receptive_field: bool = False
+    receptive_field: bool = False,
+    effective_rf_stats: bool = False,
 ) -> None:
     """Print module summary for an expected input tensor shape
 
@@ -268,6 +269,7 @@ def summary(
         wrap_mode: if a value is too long, where the wrapping should be performed
         max_depth: maximum depth of layer information
         receptive_field: whether receptive field estimation should be performed
+        effective_rf_stats: if `receptive_field` is True, displays effective stride and padding
     """
 
     # Get the summary dict
@@ -276,4 +278,4 @@ def summary(
     if isinstance(max_depth, int):
         module_info = aggregate_info(module_info, max_depth)
     # Format it and print it
-    print(format_info(module_info, wrap_mode, receptive_field))
+    print(format_info(module_info, wrap_mode, receptive_field, effective_rf_stats))

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -232,13 +232,13 @@ def crawl_module(
 
     # Update cumulative receptive field
     _rf, _s, _p = 1, 1, 0
-    for fw_idx, _layer in enumerate(info):
+    for fw_idx, _layer in enumerate(info[::-1]):
         _rf = _layer['s'] * (_rf - 1) + _layer['rf']
         _s *= _layer['s']
         _p = _layer['s'] * _p + _layer['p']
-        info[fw_idx]['rf'] = _rf
-        info[fw_idx]['s'] = _s
-        info[fw_idx]['p'] = _p
+        info[len(info) - 1 - fw_idx]['rf'] = _rf
+        info[len(info) - 1 - fw_idx]['s'] = _s
+        info[len(info) - 1 - fw_idx]['p'] = _p
 
     return dict(overheads=dict(cuda=dict(pre=cuda_overhead, fwd=get_process_gpu_ram(os.getpid()) - reserved_ram),
                                framework=dict(pre=framework_overhead, fwd=diff_ram)),

--- a/torchscan/modules/receptive.py
+++ b/torchscan/modules/receptive.py
@@ -50,7 +50,7 @@ def rf_aggregnd(
     output: Tensor
 ) -> Tuple[float, float, float]:
     k = module.kernel_size[0] if isinstance(module.kernel_size, tuple) else module.kernel_size
-    if getattr(module, 'dilation') is not None:
+    if hasattr(module, 'dilation'):
         d = module.dilation[0] if isinstance(module.dilation, tuple) else module.dilation
         k = d * (k - 1) + 1  # type: ignore[operator]
     s = module.stride[0] if isinstance(module.stride, tuple) else module.stride

--- a/torchscan/utils.py
+++ b/torchscan/utils.py
@@ -226,16 +226,14 @@ def aggregate_info(info: Dict[str, Any], max_depth: int) -> Dict[str, Any]:
                 p_size += _layer['param_size']
                 num_buffers += _layer['num_buffers']
                 b_size += _layer['buffer_size']
-                # Take the last receptive field values
-                rf, s, p = _layer['rf'], _layer['s'], _layer['p']
 
             # Update info
             info['layers'][fw_idx]['flops'] = flops
             info['layers'][fw_idx]['macs'] = macs
             info['layers'][fw_idx]['dmas'] = dmas
-            info['layers'][fw_idx]['rf'] = rf
-            info['layers'][fw_idx]['s'] = s
-            info['layers'][fw_idx]['p'] = p
+            info['layers'][fw_idx]['rf'] = info['layers'][fw_idx + 1]['rf']
+            info['layers'][fw_idx]['s'] = info['layers'][fw_idx + 1]['s']
+            info['layers'][fw_idx]['p'] = info['layers'][fw_idx + 1]['p']
             info['layers'][fw_idx]['grad_params'] = grad_p
             info['layers'][fw_idx]['nograd_params'] = nograd_p
             info['layers'][fw_idx]['param_size'] = p_size


### PR DESCRIPTION
This PR switched back to initial computation order of the receptive field, and add the possibility to display effective stride and padding.

Computing the receptive field of VGG16 with
```
from torchvision.models import vgg16
from torchscan import summary

model = vgg16().eval().cuda()
summary(model.features, (3, 224, 224), receptive_field=True, max_depth=0)
```
would yield an incorrect value before the fix:
```
____________________________________________________________________________
Layer         Type          Output Shape       Param #       Receptive field
============================================================================
sequential    Sequential    (-1, 512, 7, 7)    14,714,688    308            
============================================================================
Trainable params: 14,714,688
Non-trainable params: 0
Total params: 14,714,688
----------------------------------------------------------------------------
Model size (params + buffers): 56.13 Mb
Framework & CUDA overhead: 479.38 Mb
Total RAM usage: 535.51 Mb
----------------------------------------------------------------------------
Floating Point Operations on forward: 30.71 GFLOPs
Multiply-Accumulations on forward: 15.35 GMACs
Direct memory accesses on forward: 15.40 GDMAs
____________________________________________________________________________

```

After the fix:
```
____________________________________________________________________________
Layer         Type          Output Shape       Param #       Receptive field
============================================================================
sequential    Sequential    (-1, 512, 7, 7)    14,714,688    212            
============================================================================
Trainable params: 14,714,688
Non-trainable params: 0
Total params: 14,714,688
----------------------------------------------------------------------------
Model size (params + buffers): 56.13 Mb
Framework & CUDA overhead: 479.38 Mb
Total RAM usage: 535.51 Mb
----------------------------------------------------------------------------
Floating Point Operations on forward: 30.71 GFLOPs
Multiply-Accumulations on forward: 15.35 GMACs
Direct memory accesses on forward: 15.40 GDMAs
____________________________________________________________________________
```
