### PR TITLE
feat: Added FLOPS estimation support for nn.Transformer

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -25,59 +25,61 @@ class Tester(unittest.TestCase):
         self.assertWarns(UserWarning, modules.module_flops, MyModule(), None, None)
 
         # Common unit tests
-        self.assertEqual(modules.module_flops(nn.Linear(8, 4), torch.zeros((1, 8)), torch.zeros((1, 4))),
+        self.assertEqual(modules.module_flops(nn.Linear(8, 4), (torch.zeros((1, 8)),), torch.zeros((1, 4))),
                          4 * (2 * 8 - 1) + 4)
-        self.assertEqual(modules.module_flops(nn.Linear(8, 4, bias=False), torch.zeros((1, 8)), torch.zeros((1, 4))),
+        self.assertEqual(modules.module_flops(nn.Linear(8, 4, bias=False), (torch.zeros((1, 8)),), torch.zeros((1, 4))),
                          4 * (2 * 8 - 1))
         # Activations
-        self.assertEqual(modules.module_flops(nn.Identity(), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
-        self.assertEqual(modules.module_flops(nn.Flatten(), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
-        self.assertEqual(modules.module_flops(nn.ReLU(), torch.zeros((1, 8)), torch.zeros((1, 8))), 8)
-        self.assertEqual(modules.module_flops(nn.ELU(), torch.zeros((1, 8)), torch.zeros((1, 8))), 48)
-        self.assertEqual(modules.module_flops(nn.LeakyReLU(), torch.zeros((1, 8)), torch.zeros((1, 8))), 32)
-        self.assertEqual(modules.module_flops(nn.ReLU6(), torch.zeros((1, 8)), torch.zeros((1, 8))), 16)
-        self.assertEqual(modules.module_flops(nn.Tanh(), torch.zeros((1, 8)), torch.zeros((1, 8))), 48)
-        self.assertEqual(modules.module_flops(nn.Sigmoid(), torch.zeros((1, 8)), torch.zeros((1, 8))), 32)
+        self.assertEqual(modules.module_flops(nn.Identity(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 0)
+        self.assertEqual(modules.module_flops(nn.Flatten(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 0)
+        self.assertEqual(modules.module_flops(nn.ReLU(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 8)
+        self.assertEqual(modules.module_flops(nn.ELU(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 48)
+        self.assertEqual(modules.module_flops(nn.LeakyReLU(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 32)
+        self.assertEqual(modules.module_flops(nn.ReLU6(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 16)
+        self.assertEqual(modules.module_flops(nn.Tanh(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 48)
+        self.assertEqual(modules.module_flops(nn.Sigmoid(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 32)
 
         # BN
-        self.assertEqual(modules.module_flops(nn.BatchNorm1d(8), torch.zeros((1, 8, 4)), torch.zeros((1, 8, 4))),
+        self.assertEqual(modules.module_flops(nn.BatchNorm1d(8), (torch.zeros((1, 8, 4)),), torch.zeros((1, 8, 4))),
                          144 + 32 + 32 * 3 + 48)
 
         # Pooling
         self.assertEqual(modules.module_flops(nn.MaxPool2d((2, 2)),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          3 * 32)
         self.assertEqual(modules.module_flops(nn.AvgPool2d((2, 2)),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
         self.assertEqual(modules.module_flops(nn.AdaptiveMaxPool2d((2, 2)),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          3 * 32)
         # Check that single integer output size is supported
         self.assertEqual(modules.module_flops(nn.AdaptiveMaxPool2d(2),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          3 * 32)
         self.assertEqual(modules.module_flops(nn.AdaptiveAvgPool2d((2, 2)),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
         # Check that single integer output size is supported
         self.assertEqual(modules.module_flops(nn.AdaptiveAvgPool2d(2),
-                                              torch.zeros((1, 8, 4, 4)), torch.zeros((1, 8, 2, 2))),
+                                              (torch.zeros((1, 8, 4, 4)),), torch.zeros((1, 8, 2, 2))),
                          5 * 32)
 
         # Dropout
-        self.assertEqual(modules.module_flops(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 8)
-        self.assertEqual(modules.module_flops(nn.Dropout(p=0), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
+        self.assertEqual(modules.module_flops(nn.Dropout(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 8)
+        self.assertEqual(modules.module_flops(nn.Dropout(p=0), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 0)
 
         # Conv
         input_t = torch.rand((1, 3, 32, 32))
         mod = nn.Conv2d(3, 8, 3)
-        self.assertEqual(modules.module_flops(mod, input_t, mod(input_t)), 388800)
+        self.assertEqual(modules.module_flops(mod, (input_t,), mod(input_t)), 388800)
         # ConvTranspose
         mod = nn.ConvTranspose2d(3, 8, 3)
-        self.assertEqual(modules.module_flops(mod, input_t, mod(input_t)), 499408)
+        self.assertEqual(modules.module_flops(mod, (input_t,), mod(input_t)), 499408)
         # Transformer
         mod = nn.Transformer(nhead=4, num_encoder_layers=3)
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((20, 32, 512))
         self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 1916295945)
 
     @torch.no_grad()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -17,6 +17,7 @@ class MyModule(nn.Module):
 
 
 class Tester(unittest.TestCase):
+    @torch.no_grad()
     def test_module_flops(self):
 
         # Check for unknown module that it returns 0 and throws a warning
@@ -75,7 +76,11 @@ class Tester(unittest.TestCase):
         # ConvTranspose
         mod = nn.ConvTranspose2d(3, 8, 3)
         self.assertEqual(modules.module_flops(mod, input_t, mod(input_t)), 499408)
+        # Transformer
+        mod = nn.Transformer(nhead=4, num_encoder_layers=3)
+        self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 1916295945)
 
+    @torch.no_grad()
     def test_module_macs(self):
 
         # Check for unknown module that it returns 0 and throws a warning
@@ -122,6 +127,7 @@ class Tester(unittest.TestCase):
         # Dropout
         self.assertEqual(modules.module_macs(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 0)
 
+    @torch.no_grad()
     def test_module_dmas(self):
 
         # Check for unknown module that it returns 0 and throws a warning
@@ -169,6 +175,7 @@ class Tester(unittest.TestCase):
         # Dropout
         self.assertEqual(modules.module_dmas(nn.Dropout(), torch.zeros((1, 8)), torch.zeros((1, 8))), 17)
 
+    @torch.no_grad()
     def test_module_rf(self):
 
         # Check for unknown module that it returns 0 and throws a warning

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -146,7 +146,7 @@ def crawl_module(
                 pre_hook_tracker[id(module)]['current'] = 0
                 pre_hook_tracker[id(module)]['is_used'] = False
 
-        def _fwd_hook(module: Module, input: torch.Tensor, output: torch.Tensor) -> None:
+        def _fwd_hook(module: Module, inputs: Tuple[torch.Tensor, ...], output: torch.Tensor) -> None:
             """Post-forward hook"""
 
             # Check that another hook has not been triggered at this forward stage
@@ -168,10 +168,10 @@ def crawl_module(
                     current_rf, current_stride, current_padding = 1., 1., 0.
                 else:
                     # Compute stats for standalone layers
-                    tot_flops = module_flops(module, input[0], output)
-                    tot_macs = module_macs(module, input[0], output)
-                    tot_dmas = module_dmas(module, input[0], output)
-                    current_rf, current_stride, current_padding = module_rf(module, input[0], output)
+                    tot_flops = module_flops(module, inputs, output)
+                    tot_macs = module_macs(module, inputs[0], output)
+                    tot_dmas = module_dmas(module, inputs[0], output)
+                    current_rf, current_stride, current_padding = module_rf(module, inputs[0], output)
 
                 # Update layer information
                 info[fw_idx]['output_shape'] = (-1, *output.shape[1:])

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -6,6 +6,7 @@
 import warnings
 from functools import reduce
 from operator import mul
+from typing import Optional, Tuple
 
 from torch import nn
 from torch import Tensor
@@ -18,12 +19,12 @@ from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd,
 __all__ = ['module_flops']
 
 
-def module_flops(module: Module, input: Tensor, output: Tensor) -> int:
+def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Optional[Tensor] = None) -> int:
     """Estimate the number of floating point operations performed by the module
 
     Args:
         module: PyTorch module
-        input: input to the module
+        inputs: input to the module
         output: output of the module
     Returns:
         number of FLOPs
@@ -32,103 +33,103 @@ def module_flops(module: Module, input: Tensor, output: Tensor) -> int:
     if isinstance(module, (nn.Identity, nn.Flatten)):
         return 0
     elif isinstance(module, nn.Linear):
-        return flops_linear(module, input, output)
+        return flops_linear(module, inputs)
     elif isinstance(module, nn.ReLU):
-        return flops_relu(module, input, output)
+        return flops_relu(module, inputs)
     elif isinstance(module, nn.ELU):
-        return flops_elu(module, input, output)
+        return flops_elu(module, inputs)
     elif isinstance(module, nn.LeakyReLU):
-        return flops_leakyrelu(module, input, output)
+        return flops_leakyrelu(module, inputs)
     elif isinstance(module, nn.ReLU6):
-        return flops_relu6(module, input, output)
+        return flops_relu6(module, inputs)
     elif isinstance(module, nn.Tanh):
-        return flops_tanh(module, input, output)
+        return flops_tanh(module, inputs)
     elif isinstance(module, nn.Sigmoid):
-        return flops_sigmoid(module, input, output)
+        return flops_sigmoid(module, inputs)
     elif isinstance(module, _ConvTransposeNd):
-        return flops_convtransposend(module, input, output)
+        return flops_convtransposend(module, inputs, output)
     elif isinstance(module, _ConvNd):
-        return flops_convnd(module, input, output)
+        return flops_convnd(module, inputs, output)
     elif isinstance(module, _BatchNorm):
-        return flops_bn(module, input, output)
+        return flops_bn(module, inputs)
     elif isinstance(module, _MaxPoolNd):
-        return flops_maxpool(module, input, output)
+        return flops_maxpool(module, inputs, output)
     elif isinstance(module, _AvgPoolNd):
-        return flops_avgpool(module, input, output)
+        return flops_avgpool(module, inputs, output)
     elif isinstance(module, _AdaptiveMaxPoolNd):
-        return flops_adaptive_maxpool(module, input, output)
+        return flops_adaptive_maxpool(module, inputs, output)
     elif isinstance(module, _AdaptiveAvgPoolNd):
-        return flops_adaptive_avgpool(module, input, output)
+        return flops_adaptive_avgpool(module, inputs, output)
     elif isinstance(module, nn.Dropout):
-        return flops_dropout(module, input, output)
+        return flops_dropout(module, inputs, output)
     else:
         warnings.warn(f'Module type not supported: {module.__class__.__name__}')
         return 0
 
 
-def flops_linear(module: nn.Linear, input: Tensor, output: Tensor) -> int:
+def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * in_chan
-    mm_flops = input.shape[0] * output.shape[1] * (2 * input.shape[1] - 1)
-    bias_flops = output.numel() if module.bias is not None else 0
+    mm_flops = inputs[0].shape[0] * module.out_features * (2 * module.in_features - 1)
+    bias_flops = inputs[0].shape[0] * module.out_features if module.bias is not None else 0
 
     return mm_flops + bias_flops
 
 
-def flops_sigmoid(module: nn.Sigmoid, input: Tensor, output: Tensor) -> int:
+def flops_sigmoid(module: nn.Sigmoid, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Sigmoid`"""
 
     # For each element, mul by -1, exp it, add 1, div
-    return input.numel() * 4
+    return inputs[0].numel() * 4
 
 
-def flops_relu(module: nn.ReLU, input: Tensor, output: Tensor) -> int:
+def flops_relu(module: nn.ReLU, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.ReLU`"""
 
     # Each element is compared to 0
-    return input.numel()
+    return inputs[0].numel()
 
 
-def flops_elu(module: nn.ELU, input: Tensor, output: Tensor) -> int:
+def flops_elu(module: nn.ELU, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.ELU`"""
 
     # For each element, compare it to 0, exp it, sub 1, mul by alpha, compare it to 0 and sum both
-    return input.numel() * 6
+    return inputs[0].numel() * 6
 
 
-def flops_leakyrelu(module: nn.LeakyReLU, input: Tensor, output: Tensor) -> int:
+def flops_leakyrelu(module: nn.LeakyReLU, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.LeakyReLU`"""
 
     # For each element, compare it to 0 (max), compare it to 0 (min), mul by slope and sum both
-    return input.numel() * 4
+    return inputs[0].numel() * 4
 
 
-def flops_relu6(module: nn.ReLU6, input: Tensor, output: Tensor) -> int:
+def flops_relu6(module: nn.ReLU6, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.ReLU6`"""
 
     # For each element, compare it to 0 (max), compare it to 0 (min), mul by slope and sum both
-    return input.numel() * 2
+    return inputs[0].numel() * 2
 
 
-def flops_tanh(module: nn.Tanh, input: Tensor, output: Tensor) -> int:
+def flops_tanh(module: nn.Tanh, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Tanh`"""
 
     # For each element, exp it, mul by -1 and exp it, divide the sub by the add
-    return input.numel() * 6
+    return inputs[0].numel() * 6
 
 
-def flops_dropout(module: nn.Dropout, input: Tensor, output: Tensor) -> int:
+def flops_dropout(module: nn.Dropout, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Dropout`"""
 
     if module.p > 0:
         # Sample a random number for each input element
-        return input.numel()
+        return inputs[0].numel()
     else:
         return 0
 
 
-def flops_convtransposend(module: _ConvTransposeNd, input: Tensor, output: Tensor) -> int:
+def flops_convtransposend(module: _ConvTransposeNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.conv._ConvTranposeNd`"""
 
     # Padding (# cf. https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/conv.py#L496-L532)
@@ -136,18 +137,18 @@ def flops_convtransposend(module: _ConvTransposeNd, input: Tensor, output: Tenso
     padding_flops = len(module.kernel_size) * 8
 
     # Once padding is determined, the operations are almost identical to those of a convolution
-    conv_flops = flops_convnd(module, input, output)
+    conv_flops = flops_convnd(module, inputs, output)
 
     return padding_flops + conv_flops
 
 
-def flops_convnd(module: _ConvNd, input: Tensor, output: Tensor) -> int:
+def flops_convnd(module: _ConvNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.conv._ConvNd`"""
 
     # For each position, # mult = kernel size, # adds = kernel size - 1
     window_flops_per_chan = 2 * reduce(mul, module.kernel_size) - 1
     # Connections to input channels is controlled by the group parameter
-    effective_in_chan = (input.shape[1] // module.groups)
+    effective_in_chan = (inputs[0].shape[1] // module.groups)
     # N * flops + (N - 1) additions
     window_flops = effective_in_chan * window_flops_per_chan + (effective_in_chan - 1)
     conv_flops = output.numel() * window_flops
@@ -158,15 +159,15 @@ def flops_convnd(module: _ConvNd, input: Tensor, output: Tensor) -> int:
     return conv_flops + bias_flops
 
 
-def flops_bn(module: _BatchNorm, input: Tensor, output: Tensor) -> int:
+def flops_bn(module: _BatchNorm, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.modules.batchnorm._BatchNorm`"""
 
     # for each channel, add eps and running_var, sqrt it
     norm_ops = module.num_features * 2
     # For each element, sub running_mean, div by denom
-    norm_ops += input.numel() * 2
+    norm_ops += inputs[0].numel() * 2
     # For each element, mul by gamma, add beta
-    scale_ops = input.numel() * 2 if module.affine else 0
+    scale_ops = inputs[0].numel() * 2 if module.affine else 0
     bn_flops = norm_ops + scale_ops
 
     # Count tracking stats update ops
@@ -177,16 +178,16 @@ def flops_bn(module: _BatchNorm, input: Tensor, output: Tensor) -> int:
         if module.momentum is None:
             tracking_flops += 1
         # running_mean: by channel, sum values and div by batch size
-        tracking_flops += module.num_features * (input.shape[0] * input.shape[2:].numel())  # type: ignore[attr-defined]
+        tracking_flops += inputs[0].numel()  # type: ignore[attr-defined]
         # running_var: by channel, sub mean and square values, sum them, divide by batch size
-        tracking_flops += 3 * input.numel()  # type: ignore[attr-defined]
+        tracking_flops += 3 * inputs[0].numel()  # type: ignore[attr-defined]
         # Update both runnning stat: rescale previous value (mul by N), add it the new one, then div by (N + 1)
         tracking_flops += 2 * module.num_features * 3
 
     return bn_flops + tracking_flops
 
 
-def flops_maxpool(module: _MaxPoolNd, input: Tensor, output: Tensor) -> int:
+def flops_maxpool(module: _MaxPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._MaxPoolNd`"""
 
     k_size = reduce(mul, module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
@@ -195,40 +196,40 @@ def flops_maxpool(module: _MaxPoolNd, input: Tensor, output: Tensor) -> int:
     return output.numel() * (k_size - 1)
 
 
-def flops_avgpool(module: _AvgPoolNd, input: Tensor, output: Tensor) -> int:
+def flops_avgpool(module: _AvgPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._AvgPoolNd`"""
 
     k_size = reduce(mul, module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
-    return output.numel() * (k_size - 1 + input.ndim - 2)  # type: ignore[attr-defined]
+    return output.numel() * (k_size - 1 + inputs[0].ndim - 2)  # type: ignore[attr-defined]
 
 
-def flops_adaptive_maxpool(module: _AdaptiveMaxPoolNd, input: Tensor, output: Tensor) -> int:
+def flops_adaptive_maxpool(module: _AdaptiveMaxPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._AdaptiveMaxPoolNd`"""
 
     if isinstance(module.output_size, tuple):
         o_sizes = module.output_size
     else:
-        o_sizes = (module.output_size,) * (input.ndim - 2)  # type: ignore[attr-defined]
+        o_sizes = (module.output_size,) * (inputs[0].ndim - 2)  # type: ignore[attr-defined]
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], o_sizes))
+                        for i_size, o_size in zip(inputs[0].shape[2:], o_sizes))
 
     # for each spatial output element, check max element in kernel scope
     return output.numel() * (reduce(mul, kernel_size) - 1)
 
 
-def flops_adaptive_avgpool(module: _AdaptiveAvgPoolNd, input: Tensor, output: Tensor) -> int:
+def flops_adaptive_avgpool(module: _AdaptiveAvgPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._AdaptiveAvgPoolNd`"""
 
     if isinstance(module.output_size, tuple):
         o_sizes = module.output_size
     else:
-        o_sizes = (module.output_size,) * (input.ndim - 2)  # type: ignore[attr-defined]
+        o_sizes = (module.output_size,) * (inputs[0].ndim - 2)  # type: ignore[attr-defined]
     # Approximate kernel_size using ratio of spatial shapes between input and output
     kernel_size = tuple(i_size // o_size if (i_size % o_size) == 0 else i_size - o_size * (i_size // o_size) + 1
-                        for i_size, o_size in zip(input.shape[2:], o_sizes))
+                        for i_size, o_size in zip(inputs[0].shape[2:], o_sizes))
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
     return output.numel() * (reduce(mul, kernel_size) - 1 + len(kernel_size))

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -62,7 +62,7 @@ def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> 
     elif isinstance(module, _AdaptiveAvgPoolNd):
         return flops_adaptive_avgpool(module, inputs, output)
     elif isinstance(module, nn.Dropout):
-        return flops_dropout(module, inputs, output)
+        return flops_dropout(module, inputs)
     elif isinstance(module, nn.Transformer):
         return flops_transformer(module, inputs)
     else:
@@ -255,8 +255,8 @@ def flops_layernorm(module: nn.LayerNorm, inputs: Tuple[Tensor, ...]) -> int:
     return norm_ops + scale_ops
 
 
-def flops_mha(module: nn.TransformerEncoderLayer, inputs: Tuple[Tensor, ...]) -> int:
-    """FLOPs estimation for `torch.nn.TransformerEncoderLayer`"""
+def flops_mha(module: nn.MultiheadAttention, inputs: Tuple[Tensor, ...]) -> int:
+    """FLOPs estimation for `torch.nn.MultiheadAttention`"""
 
     # Input projection
     q, k, v = inputs[:3]
@@ -328,7 +328,7 @@ def flops_transformer_encoderlayer(module: nn.TransformerEncoderLayer, inputs: T
     tot_flops += flops_dropout(module.dropout1, inputs) + inputs[0].numel()
     tot_flops += flops_layernorm(module.norm1, inputs)
     # get linear 1 output size
-    tot_flops += flops_linear(module.linear1, inputs) + module_flops(module.activation, inputs)
+    tot_flops += flops_linear(module.linear1, inputs) + module_flops(module.activation, inputs, torch.empty(1))
     tot_flops += flops_dropout(module.dropout, inputs) + flops_linear(module.linear2, inputs)
     # get linear 2 output size
     tot_flops += flops_dropout(module.dropout2, inputs) + inputs[0].numel()
@@ -349,7 +349,7 @@ def flops_transformer_decoderlayer(module: nn.TransformerDecoderLayer, inputs: T
     tot_flops += flops_layernorm(module.norm2, inputs)
 
     # get linear 1 output size
-    tot_flops += flops_linear(module.linear1, inputs) + module_flops(module.activation, inputs)
+    tot_flops += flops_linear(module.linear1, inputs) + module_flops(module.activation, inputs, torch.empty(1))
     tot_flops += flops_dropout(module.dropout, inputs) + flops_linear(module.linear2, inputs)
     # get linear 2 output size
     tot_flops += flops_dropout(module.dropout3, inputs) + inputs[0].numel()

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -6,7 +6,7 @@
 import warnings
 from functools import reduce
 from operator import mul
-from typing import Optional, Tuple
+from typing import Tuple
 
 import torch
 from torch import nn
@@ -20,7 +20,7 @@ from torch.nn.modules.pooling import _MaxPoolNd, _AvgPoolNd, _AdaptiveMaxPoolNd,
 __all__ = ['module_flops']
 
 
-def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Optional[Tensor] = None) -> int:
+def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """Estimate the number of floating point operations performed by the module
 
     Args:


### PR DESCRIPTION
Following up on #45, this PR introduces the following modifications:
- optimized FLOPS estimation function signature
- added support for `torch.nn.Transformer`
- updated unittests accordingly