### PR TITLE
fix: Fixed MAC/FLOP computation for Linear in higher dimensions

### DIFF
--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -29,6 +29,8 @@ class Tester(unittest.TestCase):
                          4 * (2 * 8 - 1) + 4)
         self.assertEqual(modules.module_flops(nn.Linear(8, 4, bias=False), (torch.zeros((1, 8)),), torch.zeros((1, 4))),
                          4 * (2 * 8 - 1))
+        self.assertEqual(modules.module_flops(nn.Linear(8, 4), (torch.zeros((1, 2, 8)),), torch.zeros((1, 2, 4))),
+                         2 * (4 * (2 * 8 - 1) + 4))
         # Activations
         self.assertEqual(modules.module_flops(nn.Identity(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 0)
         self.assertEqual(modules.module_flops(nn.Flatten(), (torch.zeros((1, 8)),), torch.zeros((1, 8))), 0)
@@ -92,6 +94,8 @@ class Tester(unittest.TestCase):
         # Linear
         self.assertEqual(modules.module_macs(nn.Linear(8, 4), torch.zeros((1, 8)), torch.zeros((1, 4))),
                          8 * 4)
+        self.assertEqual(modules.module_macs(nn.Linear(8, 4), torch.zeros((1, 2, 8)), torch.zeros((1, 2, 4))),
+                         8 * 4 * 2)
         # Activations
         self.assertEqual(modules.module_macs(nn.ReLU(), None, None), 0)
         # Conv

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -79,7 +79,7 @@ class Tester(unittest.TestCase):
         mod = nn.ConvTranspose2d(3, 8, 3)
         self.assertEqual(modules.module_flops(mod, (input_t,), mod(input_t)), 499408)
         # Transformer
-        mod = nn.Transformer(nhead=4, num_encoder_layers=3)
+        mod = nn.Transformer(d_model=64, nhead=4, num_encoder_layers=3)
         src = torch.rand((10, 16, 64))
         tgt = torch.rand((20, 16, 64))
         self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 1916295945)

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -80,8 +80,8 @@ class Tester(unittest.TestCase):
         self.assertEqual(modules.module_flops(mod, (input_t,), mod(input_t)), 499408)
         # Transformer
         mod = nn.Transformer(nhead=4, num_encoder_layers=3)
-        src = torch.rand((10, 32, 512))
-        tgt = torch.rand((20, 32, 512))
+        src = torch.rand((10, 16, 64))
+        tgt = torch.rand((20, 16, 64))
         self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 1916295945)
 
     @torch.no_grad()

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -82,7 +82,7 @@ class Tester(unittest.TestCase):
         mod = nn.Transformer(d_model=64, nhead=4, num_encoder_layers=3)
         src = torch.rand((10, 16, 64))
         tgt = torch.rand((20, 16, 64))
-        self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 1916295945)
+        self.assertEqual(modules.module_flops(mod, (src, tgt), mod(src, tgt)), 774952841)
 
     @torch.no_grad()
     def test_module_macs(self):

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -270,7 +270,7 @@ def summary(
 
     Args:
         module: module to inspect
-        input_shape: expected input shapes
+        input_shape: expected input shapes (don't include batch size)
         wrap_mode: if a value is too long, where the wrapping should be performed
         max_depth: maximum depth of layer information
         receptive_field: whether receptive field estimation should be performed

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -34,7 +34,7 @@ def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> 
     if isinstance(module, (nn.Identity, nn.Flatten)):
         return 0
     elif isinstance(module, nn.Linear):
-        return flops_linear(module, inputs, output)
+        return flops_linear(module, inputs)
     elif isinstance(module, nn.ReLU):
         return flops_relu(module, inputs)
     elif isinstance(module, nn.ELU):
@@ -70,12 +70,13 @@ def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> 
         return 0
 
 
-def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
+def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * in_chan
-    mm_flops = reduce(mul, output.shape) * (2 * module.in_features - 1)
-    bias_flops = reduce(mul, output.shape) if module.bias is not None else 0
+    num_out_feats = module.out_features * reduce(mul, inputs[0].shape[:-1]) 
+    mm_flops = num_out_feats * (2 * module.in_features - 1)
+    bias_flops = num_out_feats if module.bias is not None else 0
 
     return mm_flops + bias_flops
 

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -34,7 +34,7 @@ def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> 
     if isinstance(module, (nn.Identity, nn.Flatten)):
         return 0
     elif isinstance(module, nn.Linear):
-        return flops_linear(module, inputs)
+        return flops_linear(module, inputs, output)
     elif isinstance(module, nn.ReLU):
         return flops_relu(module, inputs)
     elif isinstance(module, nn.ELU):
@@ -70,12 +70,12 @@ def module_flops(module: Module, inputs: Tuple[Tensor, ...], output: Tensor) -> 
         return 0
 
 
-def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...]) -> int:
+def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * in_chan
-    mm_flops = reduce(mul, inputs[0].shape) * (2 * module.in_features - 1)
-    bias_flops = reduce(mul, inputs[0].shape) if module.bias is not None else 0
+    mm_flops = reduce(mul, output.shape) * (2 * module.in_features - 1)
+    bias_flops = reduce(mul, output.shape) if module.bias is not None else 0
 
     return mm_flops + bias_flops
 

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -74,7 +74,7 @@ def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * in_chan
-    num_out_feats = module.out_features * reduce(mul, inputs[0].shape[:-1]) 
+    num_out_feats = module.out_features * reduce(mul, inputs[0].shape[:-1])
     mm_flops = num_out_feats * (2 * module.in_features - 1)
     bias_flops = num_out_feats if module.bias is not None else 0
 

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -4,7 +4,7 @@
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0.txt> for full license details.
 
 import warnings
-from functools import reduce
+from math import prod
 from operator import mul
 from typing import Tuple
 
@@ -74,8 +74,8 @@ def flops_linear(module: nn.Linear, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * in_chan
-    mm_flops = inputs[0].shape[0] * module.out_features * (2 * module.in_features - 1)
-    bias_flops = inputs[0].shape[0] * module.out_features if module.bias is not None else 0
+    mm_flops = prod(inputs[0].shape) * (2 * module.in_features - 1)
+    bias_flops = prod(inputs[0].shape) if module.bias is not None else 0
 
     return mm_flops + bias_flops
 
@@ -149,7 +149,7 @@ def flops_convnd(module: _ConvNd, inputs: Tuple[Tensor, ...], output: Tensor) ->
     """FLOPs estimation for `torch.nn.modules.conv._ConvNd`"""
 
     # For each position, # mult = kernel size, # adds = kernel size - 1
-    window_flops_per_chan = 2 * reduce(mul, module.kernel_size) - 1
+    window_flops_per_chan = 2 * prod(module.kernel_size) - 1
     # Connections to input channels is controlled by the group parameter
     effective_in_chan = (inputs[0].shape[1] // module.groups)
     # N * flops + (N - 1) additions
@@ -193,7 +193,7 @@ def flops_bn(module: _BatchNorm, inputs: Tuple[Tensor, ...]) -> int:
 def flops_maxpool(module: _MaxPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._MaxPoolNd`"""
 
-    k_size = reduce(mul, module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
+    k_size = prod(module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
 
     # for each spatial output element, check max element in kernel scope
     return output.numel() * (k_size - 1)
@@ -202,7 +202,7 @@ def flops_maxpool(module: _MaxPoolNd, inputs: Tuple[Tensor, ...], output: Tensor
 def flops_avgpool(module: _AvgPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
     """FLOPs estimation for `torch.nn.modules.pooling._AvgPoolNd`"""
 
-    k_size = reduce(mul, module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
+    k_size = prod(module.kernel_size) if isinstance(module.kernel_size, tuple) else module.kernel_size
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
     return output.numel() * (k_size - 1 + inputs[0].ndim - 2)  # type: ignore[attr-defined]
@@ -220,7 +220,7 @@ def flops_adaptive_maxpool(module: _AdaptiveMaxPoolNd, inputs: Tuple[Tensor, ...
                         for i_size, o_size in zip(inputs[0].shape[2:], o_sizes))
 
     # for each spatial output element, check max element in kernel scope
-    return output.numel() * (reduce(mul, kernel_size) - 1)
+    return output.numel() * (prod(kernel_size) - 1)
 
 
 def flops_adaptive_avgpool(module: _AdaptiveAvgPoolNd, inputs: Tuple[Tensor, ...], output: Tensor) -> int:
@@ -235,18 +235,18 @@ def flops_adaptive_avgpool(module: _AdaptiveAvgPoolNd, inputs: Tuple[Tensor, ...
                         for i_size, o_size in zip(inputs[0].shape[2:], o_sizes))
 
     # for each spatial output element, sum elements in kernel scope and div by kernel size
-    return output.numel() * (reduce(mul, kernel_size) - 1 + len(kernel_size))
+    return output.numel() * (prod(kernel_size) - 1 + len(kernel_size))
 
 
 def flops_layernorm(module: nn.LayerNorm, inputs: Tuple[Tensor, ...]) -> int:
     """FLOPs estimation for `torch.nn.modules.batchnorm._BatchNorm`"""
 
     # Compute current mean
-    norm_ops = reduce(mul, module.normalized_shape) * inputs[0].shape[:-len(module.normalized_shape)].numel()
+    norm_ops = prod(module.normalized_shape) * inputs[0].shape[:-len(module.normalized_shape)].numel()
     # current var (sub the mean, square it, sum them, divide by remaining shape)
     norm_ops += 3 * inputs[0].numel()
     # for each channel, add eps and running_var, sqrt it
-    norm_ops += reduce(mul, module.normalized_shape) * 2
+    norm_ops += prod(module.normalized_shape) * 2
     # For each element, sub running_mean, div by denom
     norm_ops += inputs[0].numel() * 2
     # For each element, mul by gamma, add beta

--- a/torchscan/modules/macs.py
+++ b/torchscan/modules/macs.py
@@ -5,7 +5,6 @@
 
 import warnings
 from functools import reduce
-from math import prod
 from operator import mul
 
 from torch import nn
@@ -58,7 +57,7 @@ def macs_linear(module: nn.Linear, input: Tensor, output: Tensor) -> int:
     """MACs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * macs_per_elt (bias already counted in accumulation)
-    mm_mac = module.in_features * prod(output.shape)
+    mm_mac = module.in_features * reduce(mul, output.shape)
 
     return mm_mac
 

--- a/torchscan/modules/macs.py
+++ b/torchscan/modules/macs.py
@@ -5,6 +5,7 @@
 
 import warnings
 from functools import reduce
+from math import prod
 from operator import mul
 
 from torch import nn
@@ -57,7 +58,7 @@ def macs_linear(module: nn.Linear, input: Tensor, output: Tensor) -> int:
     """MACs estimation for `torch.nn.Linear`"""
 
     # batch size * out_chan * macs_per_elt (bias already counted in accumulation)
-    mm_mac = input.shape[0] * output.shape[1] * input.shape[1]
+    mm_mac = module.in_features * prod(output.shape)
 
     return mm_mac
 


### PR DESCRIPTION
Following up on #50, this PR introduces the following modifications:
- fixed MAC & flop computation for nn.Linear in high dimensions
- updated unittests
- fixed arg description for summary

Closes #50 