### PR TITLE
fix: Fixed GPU RAM estimation

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run mypy
         run: |
           mypy --version
-          mypy torchscan/
+          mypy
 
   pydocstyle:
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 quality:
 	isort . -c -v
 	flake8 ./
-	mypy torchscan/
+	mypy
 	pydocstyle torchscan/
 	black --check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ exclude = ["docs*", "scripts*", "tests*"]
 
 
 [tool.mypy]
-files = "torchscan/*.py"
+files = "torchscan/"
 show_error_codes = true
 pretty = true
 warn_unused_ignores = true

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -255,7 +255,7 @@ def crawl_module(
         overheads=dict(
             cuda=dict(
                 pre=cuda_overhead,
-                fwd=get_process_gpu_ram(os.getpid()) - reserved_ram if torch.cuda.is_available() else 0.0,
+                fwd=get_process_gpu_ram(os.getpid()) - reserved_ram,
             ),
             framework=dict(pre=framework_overhead, fwd=diff_ram),
         ),

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -253,7 +253,10 @@ def crawl_module(
 
     return dict(
         overheads=dict(
-            cuda=dict(pre=cuda_overhead, fwd=get_process_gpu_ram(os.getpid()) - reserved_ram),
+            cuda=dict(
+                pre=cuda_overhead,
+                fwd=get_process_gpu_ram(os.getpid()) - reserved_ram if torch.cuda.is_available() else 0.0,
+            ),
             framework=dict(pre=framework_overhead, fwd=diff_ram),
         ),
         layers=info,

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -7,6 +7,8 @@ import re
 import subprocess
 import warnings
 
+import torch
+
 __all__ = ["get_process_gpu_ram"]
 
 
@@ -27,6 +29,13 @@ def get_process_gpu_ram(pid: int) -> float:
         for idx, _pid in enumerate(pids):
             if int(_pid) == pid:
                 return float(re.findall(r"Used GPU Memory\s+:\s([^\D]*)", res)[idx])
+
+        # Default to overall RAM usage for this process on the GPU
+        if torch.cuda.is_available():
+            ram_str = torch.cuda.list_gpu_processes().split("\n")
+            # Take the first process running on the GPU
+            if ram_str[1].startswith("process"):
+                return float(ram_str[1].split()[3])
     except Exception as e:
         warnings.warn(f"raised: {e}. Assuming no GPU is available.")
 

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -22,7 +22,7 @@ def get_process_gpu_ram(pid: int) -> float:
     """
 
     # PyTorch is not responsible for GPU usage
-    if not torch.is_available():
+    if not torch.cuda.is_available():
         warnings.warn("CUDA is unavailable to PyTorch.")
         return 0.0
 

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -32,7 +32,7 @@ def get_process_gpu_ram(pid: int) -> float:
     except Exception as e:
         warnings.warn(f"raised: {e}. Assuming no GPU is available.")
 
-    if torch.is_available():
+    if torch.cuda.is_available():
         # Default to overall RAM usage for this process on the GPU
         ram_str = torch.cuda.list_gpu_processes().split("\n")
         # Take the first process running on the GPU

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -29,15 +29,15 @@ def get_process_gpu_ram(pid: int) -> float:
         for idx, _pid in enumerate(pids):
             if int(_pid) == pid:
                 return float(re.findall(r"Used GPU Memory\s+:\s([^\D]*)", res)[idx])
-
-        # Default to overall RAM usage for this process on the GPU
-        if torch.cuda.is_available():
-            ram_str = torch.cuda.list_gpu_processes().split("\n")
-            # Take the first process running on the GPU
-            if ram_str[1].startswith("process"):
-                return float(ram_str[1].split()[3])
     except Exception as e:
         warnings.warn(f"raised: {e}. Assuming no GPU is available.")
+
+    if torch.is_available():
+        # Default to overall RAM usage for this process on the GPU
+        ram_str = torch.cuda.list_gpu_processes().split("\n")
+        # Take the first process running on the GPU
+        if ram_str[1].startswith("process"):
+            return float(ram_str[1].split()[3])
 
     # Otherwise assume the process is running exclusively on CPU
     return 0.0

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -24,7 +24,7 @@ def get_process_gpu_ram(pid: int) -> float:
     # PyTorch is not responsible for GPU usage
     if not torch.is_available():
         warnings.warn("CUDA is unavailable to PyTorch.")
-        return 0.
+        return 0.0
 
     # Query the running processes on GPUs
     try:
@@ -50,4 +50,4 @@ def get_process_gpu_ram(pid: int) -> float:
         return float(ram_str[1].split()[3])
 
     # Otherwise assume the process is running exclusively on CPU
-    return 0.
+    return 0.0


### PR DESCRIPTION
This PR fixes the GPU RAM estimation problem by:
- adding a second option to retrieve the GPU RAM information when parsing nvidia smi fails
- adding a safeguard in the crawler

What this PR will not solve:
- when several models are on the same GPUs, the RAM usage will be blended between the two. For now there is no viable solution to distinguish their RAM usage. It's thus recommended to run torchscan when no other object than your model is on GPU

Closes #63 

cc @joonas-yoon 