### PR TITLE
Update crawler.py

### DIFF
--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -179,7 +179,7 @@ def crawl_module(
                     current_rf, current_stride, current_padding = module_rf(module, inputs[0], out)
 
                 # Update layer information
-                info[fw_idx]["output_shape"] = (-1, *out.shape[1:])
+                info[fw_idx]["output_shape"] = (-1, [dim for t in (*out,) for dim in t.shape[1:]])
                 # Add them, since some modules can be used several times
                 info[fw_idx]["flops"] = tot_flops
                 info[fw_idx]["macs"] = tot_macs


### PR DESCRIPTION
fix crash with multiple output networks

# What does this PR do?

<!--
with networks with multiple outputs this code crashes as out is a tuple. a minor change was added to generate the list of shapes from all outputs.
-->

<!-- Remove if not applicable -->

Closes # (issue)


## Before submitting
- [ ] Was this discussed/approved in a Github [issue](https://github.com/frgfm/torch-scan/issues?q=is%3Aissue) or a [discussion](https://github.com/frgfm/torch-scan/discussions)? Please add a link to it if that's the case.
- [ ] You have read the [contribution guidelines](https://github.com/frgfm/torch-scan/blob/main/CONTRIBUTING.md#submitting-a-pull-request) and followed them in this PR.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/frgm/torch-scan/tree/main/docs).
- [ ] Did you write any new necessary tests?
