### PR TITLE
docs: Updates copyright year in python headers

### DIFF
--- a/.github/collect_env.py
+++ b/.github/collect_env.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/.github/verify_labels.py
+++ b/.github/verify_labels.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022, François-Guillaume Fernandez.
+# Copyright (C) 2022-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/modules/flops.py
+++ b/torchscan/modules/flops.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/modules/macs.py
+++ b/torchscan/modules/macs.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/modules/memory.py
+++ b/torchscan/modules/memory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/modules/receptive.py
+++ b/torchscan/modules/receptive.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/process/memory.py
+++ b/torchscan/process/memory.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/torchscan/utils.py
+++ b/torchscan/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022, François-Guillaume Fernandez.
+# Copyright (C) 2020-2024, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.


### PR DESCRIPTION
This PR updates the year range of the copyright in Python headers.