### PR TITLE
ci: automate annual copyright year updates

### DIFF
--- a/.github/collect_env.py
+++ b/.github/collect_env.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2024, François-Guillaume Fernandez.
+# Copyright (C) 2020-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/.github/verify_labels.py
+++ b/.github/verify_labels.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2024, François-Guillaume Fernandez.
+# Copyright (C) 2022-2026, François-Guillaume Fernandez.
 
 # This program is licensed under the Apache License 2.0.
 # See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,0 +1,60 @@
+name: Update copyright years
+
+on:
+  schedule:
+    - cron: "1 0 1 1 *"
+      timezone: "Europe/Paris"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    env:
+      TZ: Europe/Paris
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update copyright years
+        run: bash scripts/update_copyright_years.sh
+
+      - name: Check the headers
+        uses: frgfm/validate-python-headers@main
+        with:
+          license: Apache-2.0
+          owner: François-Guillaume Fernandez
+          starting-year: 2020
+          folders: .
+          ignore-files: __init__.py
+          ignore-folders: tests
+
+      - name: Open pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git diff --quiet -- '*.py' && exit 0
+
+          year="$(date +%Y)"
+          branch="automation/copyright-${year}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -u -- '*.py'
+          git commit -m "Update copyright years to ${year}"
+          git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}" || true
+          git push --force-with-lease origin "HEAD:refs/heads/${branch}"
+
+          pr_url="$(gh pr list --head "${branch}" --state open --json url --jq '.[0].url')"
+          if [[ -z "${pr_url}" ]]; then
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "Update copyright years to ${year}" \
+              --body "Automated annual update of Python copyright notices."
+          else
+            echo "Updated ${pr_url}"
+          fi

--- a/scripts/update_copyright_years.sh
+++ b/scripts/update_copyright_years.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+owner="François-Guillaume Fernandez"
+current_year="$(date +%Y)"
+notice_pattern="^# Copyright \\(C\\) ([0-9]{4})(-([0-9]{4}))?, ${owner}\\.$"
+
+cd "$(git rev-parse --show-toplevel)"
+
+if ! notices="$(git grep -n -I '^# Copyright (C) ' -- '*.py')"; then
+    echo "No Python copyright notices found." >&2
+    exit 1
+fi
+
+while IFS=: read -r file line notice; do
+    if [[ ! "${notice}" =~ ${notice_pattern} ]]; then
+        echo "${file}:${line}: unexpected copyright notice: ${notice}" >&2
+        exit 1
+    fi
+
+    start_year="${BASH_REMATCH[1]}"
+    range="${BASH_REMATCH[2]}"
+    end_year="${BASH_REMATCH[3]:-${start_year}}"
+
+    if ((start_year < 2020 || start_year > current_year || end_year > current_year)) ||
+        { [[ -n "${range}" ]] && ((end_year <= start_year)); }; then
+        echo "${file}:${line}: invalid copyright years: ${notice}" >&2
+        exit 1
+    fi
+done <<< "${notices}"
+
+git grep -l -I '^# Copyright (C) ' -- '*.py' |
+    while IFS= read -r file; do
+        sed -E -i.bak \
+            -e "s/^(# Copyright \\(C\\) [0-9]{4})-[0-9]{4}(, ${owner}\\.)$/\\1-${current_year}\\2/" \
+            -e "/^# Copyright \\(C\\) ${current_year}, ${owner}\\.$/! s/^(# Copyright \\(C\\) [0-9]{4})(, ${owner}\\.)$/\\1-${current_year}\\2/" \
+            "${file}"
+        rm -f "${file}.bak"
+    done
+
+echo "Copyright notices updated to ${current_year}."


### PR DESCRIPTION
## Summary
- add a Bash updater that validates tracked Python notices before changing their terminal year
- run it every January 1 at 00:01 Europe/Paris and open or refresh a reviewable PR
- update the two remaining stale headers on current main

## Validation
- Bash syntax and ShellCheck
- Actionlint
- transformation and rejection fixture matrix
- validate-python-headers against the full checkout
- updater idempotency and git diff --check
- Ruff formatting and lint

## Local limitation
- the repository typing check cannot resolve the uninstalled torch dependency in this checkout; CI remains the authoritative typing run