### PR TITLE
docs: improve onboarding and product guidance

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,11 +30,14 @@ jobs:
         run: |
           test -e docs/site/index.html
           test -e docs/site/installing.html
+          test -e docs/site/model-support.html
+          test -e docs/site/metrics.html
           test -e docs/site/torchscan.html
           test -e docs/site/modules.html
           test -e docs/site/process.html
           test -e docs/site/utils.html
           test -e docs/site/changelog.html
+          test -e docs/site/latest/changelog.html
       - name: Install SSH Client 🔑
         if: github.event_name == 'push'
         uses: webfactory/ssh-agent@v0.10.0

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased (0.2.0)
+
+This version is available from `main` but is not published on PyPI.
+
+- Require Python 3.11 or later and PyTorch 2.x.
+- Modernize the packaging, development, and continuous-integration toolchain.
+- Migrate the documentation to MkDocs Material.
+
 ## v0.1.2 (2022-08-03)
 
 Release note: [v0.1.2](https://github.com/frgfm/torch-scan/releases/tag/v0.1.2)

--- a/docs/docs/img/linear-counts.svg
+++ b/docs/docs/img/linear-counts.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+  <title id="title">How TorchScan counts a Linear layer</title>
+  <desc id="desc">Three input features connect to two output elements, creating six weighted connections. TorchScan counts six MACs and twelve FLOPs when bias is enabled.</desc>
+  <style>
+    text { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #17222b; }
+    .heading { font-size: 26px; font-weight: 700; }
+    .label { font-size: 17px; font-weight: 650; }
+    .body { font-size: 16px; }
+    .metric { font-size: 30px; font-weight: 750; }
+    .muted { fill: #52616b; }
+  </style>
+
+  <rect x="1" y="1" width="958" height="418" rx="14" fill="#f8fafb" stroke="#d6e0e5" stroke-width="2"/>
+  <text x="48" y="52" class="heading">A Linear layer is a set of weighted connections</text>
+  <text x="48" y="82" class="body muted">Example: Linear(3, 2), one input vector, bias enabled</text>
+
+  <text x="76" y="122" class="label">3 input features</text>
+  <text x="486" y="122" class="label">2 output elements</text>
+
+  <g fill="none" stroke-linecap="round" stroke-width="4" opacity="0.78">
+    <path d="M150 160 L550 190" stroke="#4ca68f"/>
+    <path d="M150 160 L550 280" stroke="#ff5a3d"/>
+    <path d="M150 230 L550 190" stroke="#ff5a3d"/>
+    <path d="M150 230 L550 280" stroke="#4ca68f"/>
+    <path d="M150 300 L550 190" stroke="#4ca68f"/>
+    <path d="M150 300 L550 280" stroke="#ff5a3d"/>
+  </g>
+
+  <g stroke="#28454a" stroke-width="3">
+    <circle cx="135" cy="160" r="25" fill="#ffffff"/>
+    <circle cx="135" cy="230" r="25" fill="#ffffff"/>
+    <circle cx="135" cy="300" r="25" fill="#ffffff"/>
+    <circle cx="565" cy="190" r="29" fill="#e6f6f1"/>
+    <circle cx="565" cy="280" r="29" fill="#fff0ec"/>
+  </g>
+
+  <g text-anchor="middle" dominant-baseline="middle" class="label">
+    <text x="135" y="160">x₁</text>
+    <text x="135" y="230">x₂</text>
+    <text x="135" y="300">x₃</text>
+    <text x="565" y="190">y₁</text>
+    <text x="565" y="280">y₂</text>
+  </g>
+
+  <text x="250" y="350" class="body muted">Each line is one input–output pair</text>
+
+  <rect x="660" y="112" width="250" height="246" rx="12" fill="#ffffff" stroke="#bdd0d4" stroke-width="2"/>
+  <text x="690" y="151" class="label">TorchScan counts</text>
+  <text x="690" y="199" class="metric" fill="#287f6d">6 MACs</text>
+  <text x="690" y="226" class="body muted">3 inputs × 2 outputs</text>
+  <line x1="690" y1="247" x2="880" y2="247" stroke="#d6e0e5" stroke-width="2"/>
+  <text x="690" y="290" class="metric" fill="#d8452d">12 FLOPs</text>
+  <text x="690" y="318" class="body muted">6 multiplies + 4 sums</text>
+  <text x="690" y="341" class="body muted">+ 2 bias additions</text>
+</svg>

--- a/docs/docs/img/receptive-field.svg
+++ b/docs/docs/img/receptive-field.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 420" role="img" aria-labelledby="title desc">
+  <title id="title">Receptive-field growth through sequential convolutions</title>
+  <desc id="desc">One output position starts with a one by one receptive field. One three by three convolution expands it to three by three, and a second expands it to five by five. Skip connections can invalidate this sequential estimate.</desc>
+  <defs>
+    <pattern id="grid" width="18" height="18" patternUnits="userSpaceOnUse">
+      <path d="M18 0H0V18" fill="none" stroke="#9baeb6" stroke-width="1"/>
+    </pattern>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0L10 5L0 10Z" fill="#52616b"/>
+    </marker>
+  </defs>
+  <style>
+    text { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #17222b; }
+    .heading { font-size: 26px; font-weight: 700; }
+    .label { font-size: 17px; font-weight: 650; }
+    .body { font-size: 16px; }
+    .muted { fill: #52616b; }
+  </style>
+
+  <rect x="1" y="1" width="958" height="418" rx="14" fill="#f8fafb" stroke="#d6e0e5" stroke-width="2"/>
+  <text x="48" y="52" class="heading">Receptive field grows along a sequential path</text>
+  <text x="48" y="82" class="body muted">Two 3×3 convolutions expand the input area that can affect one output value</text>
+
+  <g>
+    <rect x="88" y="118" width="126" height="126" fill="#ffffff" stroke="#779099" stroke-width="2"/>
+    <rect x="142" y="172" width="18" height="18" fill="#ff5a3d"/>
+    <rect x="88" y="118" width="126" height="126" fill="url(#grid)"/>
+
+    <rect x="417" y="118" width="126" height="126" fill="#ffffff" stroke="#779099" stroke-width="2"/>
+    <rect x="453" y="154" width="54" height="54" fill="#ffb8a8"/>
+    <rect x="417" y="118" width="126" height="126" fill="url(#grid)"/>
+
+    <rect x="746" y="118" width="126" height="126" fill="#ffffff" stroke="#779099" stroke-width="2"/>
+    <rect x="764" y="136" width="90" height="90" fill="#91d2c2"/>
+    <rect x="746" y="118" width="126" height="126" fill="url(#grid)"/>
+  </g>
+
+  <path d="M244 181H380" stroke="#52616b" stroke-width="3" marker-end="url(#arrow)"/>
+  <path d="M573 181H709" stroke="#52616b" stroke-width="3" marker-end="url(#arrow)"/>
+  <text x="312" y="163" text-anchor="middle" class="body muted">Conv 3×3</text>
+  <text x="641" y="163" text-anchor="middle" class="body muted">Conv 3×3</text>
+
+  <g text-anchor="middle">
+    <text x="151" y="279" class="label">Starting location</text>
+    <text x="151" y="307" class="body muted">1 × 1</text>
+    <text x="480" y="279" class="label">After one layer</text>
+    <text x="480" y="307" class="body muted">3 × 3</text>
+    <text x="809" y="279" class="label">After two layers</text>
+    <text x="809" y="307" class="body muted">5 × 5</text>
+  </g>
+
+  <rect x="74" y="340" width="812" height="49" rx="9" fill="#e5f5f1"/>
+  <text x="480" y="370" text-anchor="middle" class="body">TorchScan follows this order; branches and skip connections need extra caution.</text>
+</svg>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,63 +1,50 @@
 # TorchScan: inspect your PyTorch models
 
-The `torchscan` package provides tools for analyzing your PyTorch modules and models. In addition to performance benchmarks, a comprehensive architecture comparison requires insights into model complexity and its use of computational and memory resources.
+TorchScan prints the structure, parameter count, memory use, computation estimates, and receptive field of a PyTorch model.
 
-This project is meant for:
+## 60-second quickstart
 
-- :zap: **exploration**: easily assess the influence of your architecture on resource consumption
-- :woman_scientist: **research**: quickly implement your own ideas to mitigate latency
+Install the stable release:
 
-## Supported layers
+```shell
+pip install torchscan
+```
 
-Here is the list of supported layers for FLOPs, MACs, DMAs and receptive field computation:
+Then inspect a model on CPU:
 
-### Non-linear activations
+```python
+import torch.nn as nn
+from torchscan import summary
 
-- [`torch.nn.ReLU`](https://pytorch.org/docs/stable/generated/torch.nn.ReLU.html)
-- [`torch.nn.ELU`](https://pytorch.org/docs/stable/generated/torch.nn.ELU.html)
-- [`torch.nn.LeakyReLU`](https://pytorch.org/docs/stable/generated/torch.nn.LeakyReLU.html)
-- [`torch.nn.ReLU6`](https://pytorch.org/docs/stable/generated/torch.nn.ReLU6.html)
-- [`torch.nn.Tanh`](https://pytorch.org/docs/stable/generated/torch.nn.Tanh.html)
-- [`torch.nn.Sigmoid`](https://pytorch.org/docs/stable/generated/torch.nn.Sigmoid.html)
+model = nn.Sequential(
+    nn.Conv2d(3, 8, 3),
+    nn.ReLU(),
+).eval()
 
-### Linear layers
+summary(model, (3, 32, 32), max_depth=1)
+```
 
-- [`torch.nn.Identity`](https://pytorch.org/docs/stable/generated/torch.nn.Identity.html)
-- [`torch.nn.Linear`](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html)
+The output includes the model hierarchy and totals:
 
-### Convolutions
+```text
+Layer                        Type                  Output Shape              Param #
+==========================================================================================
+sequential                   Sequential            (-1, 8, 30, 30)           0
+├─0                          Conv2d                (-1, 8, 30, 30)           224
+├─1                          ReLU                  (-1, 8, 30, 30)           0
+==========================================================================================
+Trainable params: 224
+Model size (params + buffers): 0.00 Mb
+Floating Point Operations on forward: 396.00 kFLOPs
+Multiply-Accumulations on forward: 194.40 kMACs
+Direct memory accesses on forward: 216.22 kDMAs
+```
 
-- [`torch.nn.Conv1d`](https://pytorch.org/docs/stable/generated/torch.nn.Conv1d.html)
-- [`torch.nn.Conv2d`](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html)
-- [`torch.nn.Conv3d`](https://pytorch.org/docs/stable/generated/torch.nn.Conv3d.html)
-- [`torch.nn.ConvTranspose1d`](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose1d.html)
-- [`torch.nn.ConvTranspose2d`](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html)
-- [`torch.nn.ConvTranspose3d`](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose3d.html)
+`input_shape` excludes the batch dimension. TorchScan creates a synthetic batch of one on the model's current device, using its current mode; calling `eval()` avoids training-state updates during inspection.
 
-### Pooling
+## Next steps
 
-- [`torch.nn.MaxPool1d`](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html)
-- [`torch.nn.MaxPool2d`](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool2d.html)
-- [`torch.nn.MaxPool3d`](https://pytorch.org/docs/stable/generated/torch.nn.MaxPool3d.html)
-- [`torch.nn.AvgPool1d`](https://pytorch.org/docs/stable/generated/torch.nn.AvgPool1d.html)
-- [`torch.nn.AvgPool2d`](https://pytorch.org/docs/stable/generated/torch.nn.AvgPool2d.html)
-- [`torch.nn.AvgPool3d`](https://pytorch.org/docs/stable/generated/torch.nn.AvgPool3d.html)
-- [`torch.nn.AdaptiveMaxPool1d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool1d.html)
-- [`torch.nn.AdaptiveMaxPool2d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool2d.html)
-- [`torch.nn.AdaptiveMaxPool3d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveMaxPool3d.html)
-- [`torch.nn.AdaptiveAvgPool1d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool1d.html)
-- [`torch.nn.AdaptiveAvgPool2d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool2d.html)
-- [`torch.nn.AdaptiveAvgPool3d`](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool3d.html)
-
-### Normalization
-
-- [`torch.nn.BatchNorm1d`](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html)
-- [`torch.nn.BatchNorm2d`](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html)
-- [`torch.nn.BatchNorm3d`](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm3d.html)
-
-### Other
-
-- [`torch.nn.Flatten`](https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html)
-- [`torch.nn.Dropout`](https://pytorch.org/docs/stable/generated/torch.nn.Dropout.html)
-
-*Please note that the functional API of PyTorch is not supported.*
+- Choose between the stable and development releases in [Installation](installing.md).
+- Check supported inputs, outputs, and modules in [Model and input support](model-support.md).
+- Learn how to interpret estimates in [Understanding results](metrics.md).
+- See every public function in the [`torchscan` API reference](torchscan.md).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -24,7 +24,7 @@ model = nn.Sequential(
 summary(model, (3, 32, 32), max_depth=1)
 ```
 
-The output includes the model hierarchy and totals:
+Representative output (abridged):
 
 ```text
 Layer                        Type                  Output Shape              Param #

--- a/docs/docs/installing.md
+++ b/docs/docs/installing.md
@@ -1,28 +1,36 @@
 # Installation
 
-This library requires [Python](https://www.python.org/downloads/) 3.8 or higher.
+TorchScan has a published stable release and an unreleased development version:
 
-## Via Python package
+| Track | Version | Python | PyTorch |
+| --- | --- | --- | --- |
+| Stable | 0.1.2 | ≥3.6,<4 | ≥1.5,<2 |
+| Development (`main`) | 0.2.0.dev0 | ≥3.11,<4 | ≥2,<3 |
 
-Install the latest stable release of the package using [pip](https://pip.pypa.io/en/stable/installation/):
+The API reference on this site follows the development version. Use the stable release unless you specifically need to test current development.
+
+## Stable release
+
+Install from [PyPI](https://pypi.org/project/torchscan/) with pip:
 
 ```shell
 pip install torchscan
 ```
 
-## Via Conda
-
-Install the latest stable release of the package using [conda](https://docs.conda.io/en/latest/):
+Or install from [Anaconda.org](https://anaconda.org/frgfm/torchscan):
 
 ```shell
 conda install -c frgfm torchscan
 ```
 
-## Via Git
+## Development version
 
-Install the library in developer mode:
+Clone `main` and install it with [uv](https://docs.astral.sh/uv/):
 
 ```shell
 git clone https://github.com/frgfm/torch-scan.git
-pip install -e torch-scan/.
+cd torch-scan
+uv venv --python 3.11
+source .venv/bin/activate
+uv pip install -e .
 ```

--- a/docs/docs/latest/changelog.html
+++ b/docs/docs/latest/changelog.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=../changelog.html">
+    <link rel="canonical" href="https://frgfm.github.io/torch-scan/changelog.html">
+    <title>Redirecting to the TorchScan changelog</title>
+  </head>
+  <body>
+    <p>The changelog moved. <a href="../changelog.html">Continue to the current page</a>.</p>
+  </body>
+</html>

--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -20,6 +20,10 @@ input features × number of output elements
 
 Bias additions and activation functions affect FLOP counts separately; they do not turn each Linear output into one MAC.
 
+[![Three input features connected to two output elements, creating six weighted connections.](img/linear-counts.svg)](img/linear-counts.svg)
+
+For `Linear(3, 2)` on one input vector, TorchScan reports 6 MACs and 12 FLOPs when bias is enabled: 6 multiplications, 4 additions to form the two sums, and 2 bias additions.
+
 ## DMAs
 
 DMAs are modeled direct memory accesses for recognized operations. They estimate data movement from tensor shapes and module parameters; they do not measure memory bandwidth, cache behavior, or latency.
@@ -33,6 +37,8 @@ Small models and multi-GPU environments can produce noisy or even negative overh
 ## Receptive field
 
 Receptive-field values are accumulated in module execution order. This works for sequential paths, including dilation, but does not model branch topology. Residual and other skip-connected architectures can therefore produce inaccurate values.
+
+[![A receptive field expanding from one by one to three by three and five by five across two convolution layers.](img/receptive-field.svg)](img/receptive-field.svg)
 
 ## Troubleshooting
 

--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -1,0 +1,47 @@
+# Understanding results
+
+TorchScan estimates model cost from a synthetic forward pass with a batch size of one. The numbers describe that pass; they are not hardware benchmarks.
+
+## Parameters and model size
+
+Parameter and buffer counts come from the tensors registered on the model. Model size is their storage size, not the peak memory required to execute the model.
+
+## FLOPs
+
+FLOPs are floating-point operations performed during the forward pass. They are not FLOP/s, which is a throughput measurement. TorchScan uses formulas for recognized module types, so totals can omit unsupported or functional operations.
+
+## MACs
+
+A MAC is a multiply-accumulate operation. For a Linear layer, TorchScan counts:
+
+```text
+input features × number of output elements
+```
+
+Bias additions and activation functions affect FLOP counts separately; they do not turn each Linear output into one MAC.
+
+## DMAs
+
+DMAs are modeled direct memory accesses for recognized operations. They estimate data movement from tensor shapes and module parameters; they do not measure memory bandwidth, cache behavior, or latency.
+
+## GPU memory
+
+GPU memory values are process- and allocator-level snapshots around the synthetic forward pass. They do not isolate the model from framework initialization, caching, other processes, or all devices.
+
+Small models and multi-GPU environments can produce noisy or even negative overhead deltas. A negative value does not mean the model uses negative memory; treat it as an unreliable measurement and include the full environment when reporting it.
+
+## Receptive field
+
+Receptive-field values are accumulated in module execution order. This works for sequential paths, including dilation, but does not model branch topology. Residual and other skip-connected architectures can therefore produce inaccurate values.
+
+## Troubleshooting
+
+> **Unexpected zero totals:** Check for unsupported leaf modules, `torch.nn.functional` calls, tensor methods, or Python operators. These operations are not observed by module hooks.
+
+> **Negative RAM overhead:** Treat the value as measurement noise, especially for small models or multi-GPU processes. Parameter and buffer size remains separate from this estimate.
+
+> **`AttributeError` involving `shape`:** A hooked module returned a tuple, list, or dictionary. Multiple outputs are not supported.
+
+> **Data-dependent inputs fail:** TorchScan generates independent random tensors from shapes. Correlated real inputs and an `input_data` argument are not supported.
+
+See [Model and input support](model-support.md) for the complete compatibility contract and the [package reference](torchscan.md) for API details.

--- a/docs/docs/model-support.md
+++ b/docs/docs/model-support.md
@@ -1,0 +1,73 @@
+# Model and input support
+
+TorchScan attaches forward hooks to `torch.nn.Module` objects and executes one synthetic forward pass. This makes module-based models easy to inspect, but it does not trace arbitrary tensor operations.
+
+## Inputs
+
+For one tensor input, pass its shape without the batch dimension:
+
+```python
+summary(model.eval(), (3, 224, 224))
+```
+
+For multiple independent positional tensor inputs, pass a list of shapes:
+
+```python
+import torch.nn as nn
+from torchscan import summary
+
+
+class TwoInputs(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.left = nn.Linear(4, 2)
+        self.right = nn.Linear(6, 2)
+
+    def forward(self, left, right):
+        return self.left(left) + self.right(right)
+
+
+summary(TwoInputs().eval(), [(4,), (6,)])
+```
+
+The list maps to positional arguments in order. `crawl_module` also accepts one `dtype` for all inputs or an iterable with one dtype per input.
+
+TorchScan accepts shapes, not real input tensors. Inputs are generated independently with `torch.rand`, so correlated or data-dependent inputs cannot be represented. An `input_data` argument is not currently supported.
+
+## Outputs
+
+Every hooked module must return one tensor. Tuple, list, and dictionary outputs are not currently supported and can raise an `AttributeError`.
+
+## Synthetic execution
+
+- A batch dimension of one is added to every input shape.
+- Inputs use the first model parameter's device and, by default, its dtype.
+- The forward pass runs under `torch.no_grad()` but preserves the model's current training mode.
+- Calling `eval()` first is recommended because training-mode modules can update buffers.
+- The model must contain at least one parameter.
+- Exceptions from the model's forward pass are propagated.
+
+## Metric capability
+
+“Supported” means the calculator recognizes the module family. Some supported operations legitimately contribute zero or leave the receptive field unchanged.
+
+| Module family | FLOPs | MACs | DMAs | Receptive field |
+| --- | :---: | :---: | :---: | :---: |
+| Identity and Flatten | ✓ | ✓ | ✓ | ✓ |
+| Linear | ✓ | ✓ | ✓ | ✓ |
+| ReLU, ELU, LeakyReLU, ReLU6, Tanh, Sigmoid | ✓ | ✓ | ✓ | ✓ |
+| Conv1d/2d/3d and transposed convolutions | ✓ | ✓ | ✓ | ✓ |
+| BatchNorm1d/2d/3d | ✓ | ✓ | ✓ | ✓ |
+| Max, average, and adaptive pooling | ✓ | ✓ | ✓ | ✓ |
+| Dropout | ✓ | ✓ | ✓ | ✓ |
+| `torch.nn.Transformer` | ✓ | — | — | — |
+
+`torch.nn.Transformer` support does not imply support for arbitrary Transformer or `einops` implementations.
+
+## Custom and functional operations
+
+A custom composite module is inspected through its supported child modules. A custom leaf module is not understood automatically: it emits unsupported-module warnings and contributes zero or a neutral receptive-field value.
+
+Operations called through `torch.nn.functional`, tensor methods, or Python operators do not create module-hook events. They are therefore absent from the totals. For example, the addition in the multiple-input example runs normally but is not counted.
+
+See [Understanding results](metrics.md) for the consequences when comparing estimates.

--- a/docs/docs/model-support.md
+++ b/docs/docs/model-support.md
@@ -60,9 +60,9 @@ Every hooked module must return one tensor. Tuple, list, and dictionary outputs 
 | BatchNorm1d/2d/3d | ✓ | ✓ | ✓ | ✓ |
 | Max, average, and adaptive pooling | ✓ | ✓ | ✓ | ✓ |
 | Dropout | ✓ | ✓ | ✓ | ✓ |
-| `torch.nn.Transformer` | ✓ | — | — | — |
+| `torch.nn.Transformer` | ✓* | — | — | — |
 
-`torch.nn.Transformer` support does not imply support for arbitrary Transformer or `einops` implementations.
+*The low-level FLOP calculator recognizes `torch.nn.Transformer`, but `summary()` does not currently support it end to end because hooked child modules return tuples. This does not imply support for arbitrary Transformer or `einops` implementations.*
 
 ## Custom and functional operations
 

--- a/docs/docs/modules.md
+++ b/docs/docs/modules.md
@@ -1,6 +1,6 @@
 # `torchscan.modules`
 
-The modules subpackage contains tools for inspecting modules.
+The modules subpackage contains tools for inspecting modules. See [Understanding results](metrics.md) for counting conventions and [Model and input support](model-support.md) for the capability matrix.
 
 ## FLOPs
 

--- a/docs/docs/torchscan.md
+++ b/docs/docs/torchscan.md
@@ -1,5 +1,7 @@
 # `torchscan`
 
+This reference follows the development version on `main`. Read [Model and input support](model-support.md) before using non-trivial inputs, and [Understanding results](metrics.md) before comparing estimates.
+
 ## Crawler
 
 ::: torchscan.crawl_module

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: TorchScan
 site_url: https://frgfm.github.io/torch-scan
-site_description: Useful information about your PyTorch module
+site_description: PyTorch model summaries with parameter, memory, FLOP, MAC, DMA, and receptive-field estimates
 site_author: François-Guillaume Fernandez
 copyright: Copyright &copy; François-Guillaume Fernandez
 
@@ -10,6 +10,7 @@ use_directory_urls: false
 
 theme:
   name: material
+  custom_dir: overrides
   language: en
   logo: img/logo.png
   favicon: img/favicon.ico
@@ -57,9 +58,11 @@ plugins:
             show_root_heading: true
             show_root_full_path: false
             show_signature_annotations: true
+            show_source: false
             separate_signature: true
 
 markdown_extensions:
+  - tables
   - toc:
       permalink: true
   - pymdownx.emoji:
@@ -76,6 +79,9 @@ nav:
   - Home: index.md
   - Getting started:
       - Installation: installing.md
+  - Guides:
+      - Model and input support: model-support.md
+      - Understanding results: metrics.md
   - Package reference:
       - TorchScan: torchscan.md
       - Modules: modules.md

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  The API reference tracks <code>main</code> (0.2.0.dev0).
+  See <a href="{{ 'installing.html' | url }}">installation compatibility</a> for stable 0.1.2.
+{% endblock %}

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -32,6 +32,20 @@ def test_crawl_module():
     assert res["layers"][0]["output_shape"] == (-1, 8, 30, 30)
 
 
+def test_crawl_module_multiple_inputs():
+    class TwoInputs(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.left = nn.Linear(4, 2)
+            self.right = nn.Linear(6, 2)
+
+        def forward(self, left, right):
+            return self.left(left) + self.right(right)
+
+    res = crawler.crawl_module(TwoInputs(), [(4,), (6,)])
+    assert res["overall"]["grad_params"] == 24
+
+
 def test_summary():
     mod = nn.Conv2d(3, 8, 3)
 

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -36,19 +36,30 @@ def crawl_module(
     input_shape: Union[List[Tuple[int, ...]], Tuple[int, ...]],
     dtype: Optional[Union[torch.dtype, Iterable[torch.dtype]]] = None,
 ) -> Dict[str, Any]:
-    """Retrieves module information for an expected input tensor shape
+    """Collect module information using a synthetic forward pass.
 
     >>> import torch.nn as nn
-    >>> from torchscan import summary
+    >>> from torchscan import crawl_module
     >>> mod = nn.Conv2d(3, 8, 3)
     >>> module_info = crawl_module(mod, (3, 224, 224))
 
     Args:
-        module: module to inspect
-        input_shape: expected input shapes
-        dtype: data type of each input argument to the module
+        module: Module to inspect. It must contain at least one parameter.
+        input_shape: Input shape without a batch dimension, or one shape per positional tensor input.
+        dtype: One data type for every input, or one data type per input. Defaults to the first parameter's data type.
+
     Returns:
-        layer and overhead information
+        A dictionary containing per-layer information in `layers`, parameter and buffer totals in `overall`, and
+        process and framework memory estimates in `overheads`.
+
+    Raises:
+        StopIteration: If the module has no parameters.
+        AttributeError: If a hooked module returns something other than a tensor.
+
+    Notes:
+        This runs a random batch of one on the first parameter's device, without gradients, in the module's current
+        training mode. Functional operations are not observed by module hooks. See the model-support and metrics guides
+        for the complete limitations.
     """
     # Get device and data types from model
     p = next(module.parameters())
@@ -267,13 +278,13 @@ def crawl_module(
 
 def summary(
     module: Module,
-    input_shape: Tuple[int, ...],
+    input_shape: Union[List[Tuple[int, ...]], Tuple[int, ...]],
     wrap_mode: str = "mid",
     max_depth: Optional[int] = None,
     receptive_field: bool = False,
     effective_rf_stats: bool = False,
 ) -> None:
-    """Print module summary for an expected input tensor shape
+    """Print a module summary for one or more expected tensor input shapes.
 
     >>> import torch.nn as nn
     >>> from torchscan import summary
@@ -281,12 +292,20 @@ def summary(
     >>> summary(mod, (3, 224, 224), receptive_field=True)
 
     Args:
-        module: module to inspect
-        input_shape: expected input shapes (don't include batch size)
-        wrap_mode: if a value is too long, where the wrapping should be performed
-        max_depth: maximum depth of layer information
-        receptive_field: whether receptive field estimation should be performed
-        effective_rf_stats: if `receptive_field` is True, displays effective stride and padding
+        module: Module to inspect. It must contain at least one parameter.
+        input_shape: Input shape without a batch dimension, or one shape per positional tensor input.
+        wrap_mode: Wrap long layer names at the middle (`"mid"`) or end (`"end"`).
+        max_depth: Maximum depth of layer information.
+        receptive_field: Whether to estimate receptive fields.
+        effective_rf_stats: If `receptive_field` is true, also display effective stride and padding.
+
+    Raises:
+        StopIteration: If the module has no parameters.
+        AttributeError: If a hooked module returns something other than a tensor.
+        ValueError: If `wrap_mode` is invalid or `max_depth` is greater than the module depth.
+
+    Notes:
+        This function has the same synthetic-forward and module-hook limitations as `crawl_module`.
     """
     # Get the summary dict
     module_info = crawl_module(module, input_shape)

--- a/torchscan/crawler.py
+++ b/torchscan/crawler.py
@@ -38,10 +38,11 @@ def crawl_module(
 ) -> Dict[str, Any]:
     """Collect module information using a synthetic forward pass.
 
-    >>> import torch.nn as nn
-    >>> from torchscan import crawl_module
-    >>> mod = nn.Conv2d(3, 8, 3)
-    >>> module_info = crawl_module(mod, (3, 224, 224))
+    Examples:
+        >>> import torch.nn as nn
+        >>> from torchscan import crawl_module
+        >>> mod = nn.Conv2d(3, 8, 3)
+        >>> module_info = crawl_module(mod, (3, 224, 224))
 
     Args:
         module: Module to inspect. It must contain at least one parameter.
@@ -286,10 +287,11 @@ def summary(
 ) -> None:
     """Print a module summary for one or more expected tensor input shapes.
 
-    >>> import torch.nn as nn
-    >>> from torchscan import summary
-    >>> mod = nn.Conv2d(3, 8, 3)
-    >>> summary(mod, (3, 224, 224), receptive_field=True)
+    Examples:
+        >>> import torch.nn as nn
+        >>> from torchscan import summary
+        >>> mod = nn.Conv2d(3, 8, 3)
+        >>> summary(mod, (3, 224, 224), receptive_field=True)
 
     Args:
         module: Module to inspect. It must contain at least one parameter.


### PR DESCRIPTION
## Summary
- distinguish stable 0.1.2 from main and 0.2 development
- add a runnable quickstart plus model-support and metric guides
- document runtime limitations, tighten generated API docs, and preserve the legacy changelog URL

## Validation
- make build-docs
- make quality
- make test (72 passed)
- make precommit
- quickstart and multi-input smoke tests
- 254 internal links checked; 10 local routes return HTTP 200

## Adversarial review
- OpenCode: clean-merge verdict; non-applicable crawl_module wrap-mode nit rejected
- Cursor: Transformer support clarification applied; multi-input regression test added
- Codex: harness unavailable after timeout
- Claude: intentionally excluded per request